### PR TITLE
simplify join names for more pleasant graphql queries

### DIFF
--- a/backend/start_postgraphile.sh
+++ b/backend/start_postgraphile.sh
@@ -15,6 +15,7 @@ npx postgraphile \
   --allow-explain \
   --cors \
   --enable-query-batching \
+  --append-plugins @graphile-contrib/pg-simplify-inflector \
   --legacy-relations omit \
   --connection $DATABASE_URL \
   --jwt-token-identifier app.jwt_token  \


### PR DESCRIPTION
Queries now become simpler. Instead of 

```graphql
query {
  allPeople {
    id
    fullName
    mealPlanByMealPlanId {
       ...
    }
  }
}
```

you can now write the following

```graphql
query {
  people {
    id
    fullName
    mealPlan {
       ...
    }
  }
}
```