### PR TITLE
Fix #241, Fix #214 multiple permissions fixes

### DIFF
--- a/backend/001-auth-system.sql
+++ b/backend/001-auth-system.sql
@@ -124,16 +124,23 @@ begin;
 
   alter table app.person enable row level security;
 
-  -- consider removing select for anonymous
-  create policy select_person 
+  -- admins and meal designers can see all users, others can see only themselves 
+  create policy select_person_user 
     on app.person 
-    for select using (true);
+    for select 
+    to app_user using (id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+  create policy select_person_meal_designer 
+    on app.person 
+    for select 
+    to app_meal_designer using (true);
 
   create policy all_person_admin
     on app.person 
     for all
     to app_admin using (true);
 
+  -- users and meal designers can only update themselves
   create policy update_person_user
     on app.person 
     for update

--- a/backend/007-meal-plan-entry.sql
+++ b/backend/007-meal-plan-entry.sql
@@ -45,6 +45,6 @@ create policy all_meal_plan_entry_meal_designer
 create policy all_meal_plan_entry_user
   on app.meal_plan_entry
   for all
-  to app_user using(meal_plan_id in (select meal_plan_id from app.meal_plan)); -- NOTE: depends on meal_plan row level policy
+  to app_user using(meal_plan_id in (select id from app.meal_plan where person_id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint)); -- NOTE: depends on meal_plan row level policy
 
 COMMIT;

--- a/backend/007-meal-plan-entry.sql
+++ b/backend/007-meal-plan-entry.sql
@@ -26,8 +26,25 @@ for each row execute procedure app.set_created_at();
 create index idx_meal_plan_entry_meal_plan_id on app.meal_plan_entry(meal_plan_id);
 create index idx_meal_plan_entry_meal_id on app.meal_plan_entry(meal_id);
 
-GRANT select, insert, delete, update on app.meal_plan_entry to app_meal_designer, app_admin;
-GRANT select on app.meal_plan_entry to app_anonymous, app_user;
-GRANT usage on SEQUENCE app.meal_plan_entry_id_seq to app_meal_designer, app_admin;
+GRANT select, insert, delete, update on app.meal_plan_entry to app_user, app_meal_designer, app_admin;
+GRANT select on app.meal_plan_entry to app_anonymous;
+GRANT usage on SEQUENCE app.meal_plan_entry_id_seq to app_user, app_meal_designer, app_admin;
+
+alter table app.meal_plan_entry enable row level security;
+
+create policy all_meal_plan_entry_admin
+  on app.meal_plan_entry
+  for all
+  to app_admin using(true);
+
+create policy all_meal_plan_entry_meal_designer
+  on app.meal_plan_entry
+  for all
+  to app_meal_designer using(true);
+
+create policy all_meal_plan_entry_user
+  on app.meal_plan_entry
+  for all
+  to app_user using(meal_plan_id in (select meal_plan_id from app.meal_plan)); -- NOTE: depends on meal_plan row level policy
 
 COMMIT;

--- a/backend/migrations/001-241-meal-plan-entry-policy.sql
+++ b/backend/migrations/001-241-meal-plan-entry-policy.sql
@@ -44,7 +44,7 @@ drop policy if exists all_meal_plan_entry_user on app.meal_plan_entry;
 create policy all_meal_plan_entry_user
   on app.meal_plan_entry
   for all
-  to app_user using(meal_plan_id in (select meal_plan_id from app.meal_plan)); -- NOTE: depends on meal_plan row level policy
+  to app_user using(meal_plan_id in (select id from app.meal_plan where person_id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint)); -- NOTE: depends on meal_plan row level policy
 
 
 COMMIT;

--- a/backend/migrations/001-241-meal-plan-entry-policy.sql
+++ b/backend/migrations/001-241-meal-plan-entry-policy.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+-- ensure that regular, unprivileged user's new plans are automatically assigned to them
+-- if they aren't, the insert violates row level policy
+create or replace function app.set_meal_plan_new_person_id() returns trigger as $$
+  begin
+    if current_user = 'app_user' then
+      new.person_id := nullif(current_setting('jwt.claims.person_id', true), '')::bigint;
+    end if;
+    return new;
+  end;
+  $$ language plpgsql;
+
+drop trigger if exists tg_meal_plan_set_app_user_person_id on app.meal_plan;
+create trigger tg_meal_plan_set_app_user_person_id before insert
+  on app.meal_plan
+  for each row execute procedure app.set_meal_plan_new_person_id();
+
+
+-- allow regular users to update meal plan entries	
+GRANT insert, delete, update on app.meal_plan_entry to app_user;
+GRANT usage on SEQUENCE app.meal_plan_entry_id_seq to app_user;
+
+-- add row level perms to restrict which entries can be updated
+alter table app.meal_plan_entry enable row level security;
+
+-- admin can work on any meal plan and its entries
+drop policy if exists all_meal_plan_entry_admin on app.meal_plan_entry;
+create policy all_meal_plan_entry_admin
+  on app.meal_plan_entry
+  for all
+  to app_admin using(true);
+
+-- meal designer can work on any meal plan and its entries
+drop policy if exists all_meal_plan_entry_meal_designer on app.meal_plan_entry;
+create policy all_meal_plan_entry_meal_designer
+  on app.meal_plan_entry
+  for all
+  to app_meal_designer using(true);
+
+-- user can only see or update entries beloning to their own meal plans
+-- IMPORTANT: the row level policy on meal_plan must be in place for this to work
+drop policy if exists all_meal_plan_entry_user on app.meal_plan_entry;
+create policy all_meal_plan_entry_user
+  on app.meal_plan_entry
+  for all
+  to app_user using(meal_plan_id in (select meal_plan_id from app.meal_plan)); -- NOTE: depends on meal_plan row level policy
+
+
+COMMIT;

--- a/backend/migrations/002-214-reduce-person-visibility.sql
+++ b/backend/migrations/002-214-reduce-person-visibility.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+  -- admins and meal designers can see all users, others can see only themselves 
+  drop policy if exists select_person on app.person;
+  drop policy if exists select_person_user on app.person;
+  drop policy if exists select_person_meal_designer on app.person;
+
+  create policy select_person_user
+    on app.person
+    for select
+    to app_user using (id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+  create policy select_person_meal_designer
+    on app.person
+    for select
+    to app_meal_designer using (true);
+
+COMMIT;


### PR DESCRIPTION
User can create and edit plans.  New plans will be automatically assigned to the user, if they are not an admin or meal designer. Added row level policies to allow users to add and remove meals from their own plans.

Updated the row level policies for Person to ensure that only admins and meal designers can see all users (such as in drop downs for filtering and assignment). regular users can only 'see' themselves.
