### PR TITLE
Fixed the blank page issue when mealplan is unassigned

### DIFF
--- a/meal-planner-fredericton-ui/src/ShoppingList/ShoppingList.jsx
+++ b/meal-planner-fredericton-ui/src/ShoppingList/ShoppingList.jsx
@@ -77,14 +77,11 @@ const ShoppingListDisplay = ({ mealPlan }) => {
     totalPrice = parseFloat(totalPrice).toFixed(2);
     return (
         <div>
-            {/* {JSON.stringify(props.mealPlan)} */}
-            {console.log("mealplan person", mealPlan.person)}
-
             <Grid container fluid>
                 <Grid container spacing="5">
                     <Grid item>
                         <Typography variant="caption">
-                            Prepared for {mealPlan.person.fullName}
+                            {mealPlan.person &&  `Prepared for ${mealPlan.person.fullName}`}
                         </Typography>
                     </Grid>
                     <Grid item>


### PR DESCRIPTION
Added a check to see whether the person field is not null before displaying the fullname. Incase it is null, the person name won't be displayed. This fixes the bug #240 