### PR TITLE
[#389] - Register user should not allow different password. 

### DIFF
--- a/admin-ui/src/People/Register.tsx
+++ b/admin-ui/src/People/Register.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   InputAdornment,
   TextField,
+  Typography,
 } from "@mui/material";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -19,6 +20,7 @@ export const Register = () => {
   const client = useApolloClient();
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
+
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
@@ -26,6 +28,7 @@ export const Register = () => {
     <Grid container>
       <Grid xs={12}>
         <TextField
+          required
           fullWidth
           label="Full Name"
           value={fullName}
@@ -34,6 +37,7 @@ export const Register = () => {
           }}
         />
         <TextField
+          required
           fullWidth
           label="Email"
           value={email}
@@ -42,6 +46,7 @@ export const Register = () => {
           }}
         />
         <TextField
+          required
           fullWidth
           label="Password"
           type={showPassword ? "text" : "password"}
@@ -67,6 +72,7 @@ export const Register = () => {
           }}
         />
         <TextField
+          required
           fullWidth
           label="Confirm Password"
           type={showPassword ? "text" : "password"}
@@ -75,7 +81,15 @@ export const Register = () => {
             setCPassword(e.target.value);
           }}
         />
+        {password && fullName && email && password === cPassword ? (
+          <></>
+        ) : (
+          <Typography variant="body2" color="red">
+            Passwords should match and all fields are required
+          </Typography>
+        )}
         <Button
+          disabled={!(password && password === cPassword && fullName && email)}
           onClick={(e) => {
             e.stopPropagation();
             registerPerson(client, fullName, email, password).then(() => {

--- a/admin-ui/src/People/Register.tsx
+++ b/admin-ui/src/People/Register.tsx
@@ -20,7 +20,7 @@ export const Register = () => {
   const client = useApolloClient();
   const navigate = useNavigate();
   const [showPassword, setShowPassword] = useState(false);
-
+  const isValid = password && password === cPassword && fullName && email;
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
@@ -81,7 +81,7 @@ export const Register = () => {
             setCPassword(e.target.value);
           }}
         />
-        {password && fullName && email && password === cPassword ? (
+        {isValid ? (
           <></>
         ) : (
           <Typography variant="body2" color="red">
@@ -89,7 +89,7 @@ export const Register = () => {
           </Typography>
         )}
         <Button
-          disabled={!(password && password === cPassword && fullName && email)}
+          disabled={!isValid}
           onClick={(e) => {
             e.stopPropagation();
             registerPerson(client, fullName, email, password).then(() => {


### PR DESCRIPTION
Password match needs to be checked.

**Describe the technical changes contained in this PR**
Changed all input fields as required. Created a check whether text fields user name, email id, password are not empty and that password and compare password are exactly the same. If it is same, only then enable the button to register (create) a user. Otherwise show a default message 'Passwords should match and all fields are required'.

**Previous behaviour**
Despite differences in password and compare password, the element was created with password. Also since none of the fields were not mandatory, it was possible to create user without name or email id or password.

**New behaviour**
Only if all fields are entered and the password matches with the compare password, the register button gets enabled. By default the message 'Passwords should match and all fields are required' appears.

**Related issues addressed by this PR**
Fixes #389 