### PR TITLE
[#357] - Meal plan name should not be empty on edit meal plan

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -95,13 +95,15 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
               style={{ backgroundColor: theme.palette.primary.light }}
               defaultValue={data.nameEn}
               onBlur={(e) => {
-                updateMealPlanName(data.rowId, {
-                  mealPlanId: data.rowId,
-                  descriptionEn: data.descriptionEn,
-                  personId: data.person?.rowId,
-                  tags: data.tags,
-                  mealPlanName: e.target.value,
-                });
+                e.target.value
+                  ? updateMealPlanName(data.rowId, {
+                      mealPlanId: data.rowId,
+                      descriptionEn: data.descriptionEn,
+                      personId: data.person?.rowId,
+                      tags: data.tags,
+                      mealPlanName: e.target.value,
+                    })
+                  : (e.target.value = data.nameEn);
                 setIsEditName(false);
               }}
             />


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
When we click on Edit meal plan and enter an empty value, on blur we reassign the original value without updating the meal plan name to a blank value. Only if it is non-empty value, then updateMealPlan function is called with the new value of meal plan name.

**Previous behaviour**
When an empty value is entered in the Meal plan name while editing in the Meal plan page, then the empty value was saved and the input field disappears giving no way to bring back the meal plan name.

**New behaviour**
Now empty value is not allowed while editing the meal plan name. It would revert to the earlier meal plan name when edited with an empty value on blur.

**Related issues addressed by this PR**
Fixes #357 