### PR TITLE
Altered the table to add on delete cascade.

### DIFF
--- a/backend/005-426-measure-on-delete-cascase.sql
+++ b/backend/005-426-measure-on-delete-cascase.sql
@@ -1,0 +1,6 @@
+alter table app.measure
+drop constraint measure_meal_id_fkey,
+add constraint measure_meal_id_fkey
+   foreign key (meal_id)
+   references app.meal(id)
+   on delete cascade;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Altered the table and added ON DELETE CASCADE on the table measures for the field meal_id.

**Previous behaviour**
Previously, when I tried to delete a single meal from the meals table I was getting an error "foreign key constraint".

**New behaviour**
But after altering the table I was able to delete a single meal and the associated measures.
