### PR TITLE
Changed the placeholder for search meal in meals page

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -163,7 +163,7 @@ export const Meals = () => {
       >
         <InputBase
           sx={{ ml: 1, flex: 1 }}
-          placeholder="Search Meal plan"
+          placeholder="Search Meal"
           inputProps={{ "aria-label": "Search Meal" }}
         />
         <Search></Search>


### PR DESCRIPTION
** Describe the technical changes contained in this PR**

I made the following change to address this bug
Modified the placeholder text in search bar on the Meals page from "Search Meal plans" to "Search Meal". This placeholder text will reflect the appropriate context.

**Previous behaviour**
Prior to this change, the placeholder text in the search box on the Meals page incorrectly referenced "Search Meal plans" instead of "Search Meal", this might create confusion to users when searching for specific meals.

**New behaviour**
After implementing this change, the placeholder text in the search bar now correctly reflects "Search Meal" in the Meals page. This change makes it easy for users to identify the purpose of the search box.

**Related issues addressed by this PR**
Fixes #443 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ No] Does this change break or alter existing behaviour?

