### PR TITLE
username will be displayed as no user assigned on mealplan calendar

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -163,9 +163,11 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
               textTransform={"capitalize"}
               fontStyle="normal"
               onClick={(e) => setIsEditUser(true)}
-            >
-              {data.person?.fullName}
-            </Typography>
+            > 
+            {data.person?.fullName ? data.person.fullName : "No User Assigned"}
+              
+
+            </Typography> 
           )}
         </Box>
 

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -166,7 +166,6 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
             > 
             {data.person?.fullName ? data.person.fullName : "No User Assigned"}
               
-
             </Typography> 
           )}
         </Box>


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
In the MealPlanHeader.tsx file in mealplanner-ui, I have added a conditional statement where if the person object is not null, it prints the person's name. If it is null, it prints "user not assigned".

**Previous behaviour**
In the meal plans page when creating a new meal plan, the assign user field can be left blank and the new meal plan is created with no user assigned to the meal plan. Then, in the meal plans calendar there is no way to assign a user to the meal plan.

**New behaviour**
Now, if a meal plan has no user assigned, the meal plan calendar displays "no user assigned" and now we can assign a user to the meal plan.

**Related issues addressed by this PR**
Fixes #456

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes? yes
- [ ] Do all of the test cases pass? yes
- [ ] Has the testing been done using the default docker-compose environment? yes
- [ ] Are documentation changes required? no
- [ ] Does this change break or alter existing behaviour? yes, we can now assign user to a mealplan if mealplan was created with no user assigned