### PR TITLE
#460 delete confirmation dialog

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -169,7 +169,6 @@ const MealPlanCard = (props: MealPlanCardProps) => {
                 fullScreen={fullScreenDialog}
                 open={openDialog}
                 onClick={(e) => {
-                  e.preventDefault();
                   e.stopPropagation();
                 }}
                 onClose={handleClose}

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -3,11 +3,17 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
   Avatar,
+  Button,
   Card,
   CardActions,
   CardContent,
   CardHeader,
   Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Grid,
   IconButton,
   IconButtonProps,
@@ -17,6 +23,8 @@ import {
   Paper,
   styled,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
 import React, { useState } from "react";
@@ -91,12 +99,32 @@ const getInitials = (name: string) => {
 
 const MealPlanCard = (props: MealPlanCardProps) => {
   const [expanded, setExpanded] = React.useState(false);
+  const [openDialog, setOpenDialog] = React.useState(false);
+  const theme = useTheme();
+  const fullScreenDialog = useMediaQuery(theme.breakpoints.down('md'));
   const navigate = useNavigate();
   const mealplan = props.mealplan;
   const connection = props.connection;
   const handleExpandClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     setExpanded(!expanded);
+  };
+
+  const handleClickOpen = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setOpenDialog(true);
+  };
+
+  const handleClose = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setOpenDialog(false);
+  };
+
+  const handleDelete =(e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log("meal plan id: ", typeof mealplan.rowId);
+    deleteMealPlan(connection, mealplan.rowId);
+    setOpenDialog(false);
   };
 
   return (
@@ -130,16 +158,46 @@ const MealPlanCard = (props: MealPlanCardProps) => {
               >
                 <ShoppingCart />
               </IconButton>
+
               <IconButton
                 aria-label="delete"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log("meal plan id: ", typeof mealplan.rowId);
-                  deleteMealPlan(connection, mealplan.rowId);
-                }}
+                onClick = {handleClickOpen}
               >
                 <DeleteTwoTone />
               </IconButton>
+              <Dialog
+                fullScreen={fullScreenDialog}
+                open={openDialog}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onClose={handleClose}
+                aria-labelledby="delete-dialog"
+              >
+                <DialogTitle id="delete-dialog">
+                  {"Delete this meal plan?"}
+                </DialogTitle>
+                <DialogContent>
+                  <DialogContentText>
+                    Are you sure you want to delete this meal plan?
+                  </DialogContentText>
+                </DialogContent>
+                    
+                <DialogActions>
+                  <Button 
+                    onClick={handleDelete}
+                    autoFocus
+                    startIcon={<DeleteTwoTone />}
+                    color = "error"
+                  >
+                    Delete
+                  </Button>
+                  <Button autoFocus onClick={handleClose}>
+                    Cancel
+                  </Button>
+                </DialogActions>
+              </Dialog>
             </div>
           }
           title={mealplan.nameEn}


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
in the MealPlans.tsx file, a dialog is added as well as three functions created to support the dialog actions (handleClickOpen, handleClose, handleDelete). I have moved the code that actually deletes the meal plan into the handleDelete function, so that it deletes meal plan only when the button in the confirmation dialog is clicked.
**Previous behaviour**
When the user goes to delete a meal plan, upon clicking the trash can icon the selected meal plan is deleted immediately, not taking consideration that the user's action could've been a mistake.
**New behaviour**
When the user goes to delete a meal plan, upon clicking the trash icon, a confirmation dialogue pops up so that the user can confirm on whether or not to actually delete the selected meal plan. This way, less mistakes are made
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/2fc0c1d2-36f4-4828-b9df-d1c32c9ba5f6)

**Related issues addressed by this PR**
Fixes #460

**Have the following been addressed?**
- [x] Have test cases been created for all of the changes?
- [x] Do all of the test cases pass?
- [x] Has the testing been done using the default docker-compose environment?
- [x] Are documentation changes required?
- [x] Does this change break or alter existing behaviour?

