### PR TITLE
[#476] favourites icon turn red on mouse hover

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -169,7 +169,7 @@ const MealPlanCard = (props: MealPlanCardProps) => {
           </Typography>
         </CardContent>
         <CardActions disableSpacing>
-          <IconButton aria-label="add to favorites">
+          <IconButton aria-label="add to favorites" sx={{ "& :hover": { color: "#dc143c" } }}>
             <FavoriteIcon />
           </IconButton>
 


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
in the MealPlans.tsx file, I have added code to the favourites IconButton so that the icon turns red on mouse hover

**Previous behaviour**
When the user hovers their mouse over the favourites/heart icon, the icon stays a grey colour:
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/55cb1cf2-80b7-45c3-b98b-892d86fb5eb2)


**New behaviour**
When the user hovers their mouse over the favourites/heart icon, the icon now turns red:
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/5da5fcb9-1d3d-4362-9f29-9930d3f31c3b)

**Related issues addressed by this PR**
Fixes #476

**Have the following been addressed?**
- [x] Have test cases been created for all of the changes?
- [x] Do all of the test cases pass?
- [x] Has the testing been done using the default docker-compose environment?
- [x] Are documentation changes required?
- [x] Does this change break or alter existing behaviour?

