### PR TITLE
[#483] fixes tags in admin app

### DIFF
--- a/admin-ui/src/Products/ProductForm.tsx
+++ b/admin-ui/src/Products/ProductForm.tsx
@@ -12,7 +12,14 @@ export const ProductForm = () => {
       <BooleanInput source="isArchived" />
       <TextInput source="upc" />
       <TextInput source="sourceLink" />
-      <TextInput source="tags" />
+      <TextInput 
+        defaultValue={null}
+        fullWidth
+        parse={(values) => {
+          if(values == '') return null;
+          return values.split(",").map((s: string) => s.trim())
+        }}
+        source="tags" />
     </SimpleForm>
   );
 };


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
In the 'admin-ui' folder, within the 'ProductForm.tsx' file, I've included code that allows multiple tags to be created when the user inputs tags separated with commas.

**Previous behaviour**
In the Admin app, when the user creates a product and fills in the "tags" entry, tags are not getting created correctly. For example, "vegan,grocery" should be separated into 2 tags "vegan", "grocery". however, this does not happen.

**New behaviour**
Now in the Admin app, when the user creates a product and fills in the "tags" entry, with more than 1 tags, they are created correctly.

**Related issues addressed by this PR**
Fixes #483

**Have the following been addressed?**
- [x] Have test cases been created for all of the changes?
- [x] Do all of the test cases pass?
- [x] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [x] Does this change break or alter existing behaviour?

