### PR TITLE
441 unit conversion table for products

### DIFF
--- a/admin-ui/src/Products/ProductList.tsx
+++ b/admin-ui/src/Products/ProductList.tsx
@@ -2,7 +2,6 @@ import {
   BooleanField,
   Datagrid,
   EditButton,
-  FunctionField,
   List,
   ListProps,
   NumberField,
@@ -15,43 +14,6 @@ import { ListField } from "../ListField";
 import { NutritionShow } from "../Nutrition/NutritionShow";
 
 export const ProductList = (props: ListProps) => {
-  const convertToKilograms = (value: number, unit: string) => {
-    if (unit === "g") {
-      return value / 1000;
-    } else if (unit === "lb") {
-      return value / 2.20;
-    } else {
-      return value;
-    }
-  };
-
-  const formatUnit = (unit: string) => {
-    if (
-      unit === "kg" ||
-      unit === "L" ||
-      unit === "mL" ||
-      unit === "ml" ||
-      unit === "oz" ||
-      unit === "piece" ||
-      unit === "single" ||
-      unit === "bunch" ||
-      unit === "pack" ||
-      unit === "count"
-    ) {
-      return unit;
-    } else {
-      return "kg";
-    }
-  };
-  
-  const convertAndFormatValue = (record: any) => {
-    const value = record.quantity;
-    const unit = record.unit;
-    const convertedValue = convertToKilograms(value, unit);
-    const formattedUnit = formatUnit(unit);
-    return `${convertedValue} ${formattedUnit}`;
-  };
-
   return (
     <List {...props} title="ProductList">
       <Datagrid expand={NutritionDetails}>
@@ -60,10 +22,8 @@ export const ProductList = (props: ListProps) => {
         <TextField source="nameFr" fullWidth />
         <TextField source="code" />
         <NumberField source="price" />
-        <FunctionField
-          label="Quantity"
-          render={(record: any) => convertAndFormatValue(record)}
-        />
+        <NumberField source="quantity" />
+        <TextField source="unit" />
         <BooleanField source="isArchived" />
         <TextField source="upc" />
         <UrlField source="sourceLink" />

--- a/admin-ui/src/Products/ProductList.tsx
+++ b/admin-ui/src/Products/ProductList.tsx
@@ -2,6 +2,7 @@ import {
   BooleanField,
   Datagrid,
   EditButton,
+  FunctionField,
   List,
   ListProps,
   NumberField,
@@ -14,6 +15,43 @@ import { ListField } from "../ListField";
 import { NutritionShow } from "../Nutrition/NutritionShow";
 
 export const ProductList = (props: ListProps) => {
+  const convertToKilograms = (value: number, unit: string) => {
+    if (unit === "g") {
+      return value / 1000;
+    } else if (unit === "lb") {
+      return value / 2.20;
+    } else {
+      return value;
+    }
+  };
+
+  const formatUnit = (unit: string) => {
+    if (
+      unit === "kg" ||
+      unit === "L" ||
+      unit === "mL" ||
+      unit === "ml" ||
+      unit === "oz" ||
+      unit === "piece" ||
+      unit === "single" ||
+      unit === "bunch" ||
+      unit === "pack" ||
+      unit === "count"
+    ) {
+      return unit;
+    } else {
+      return "kg";
+    }
+  };
+  
+  const convertAndFormatValue = (record: any) => {
+    const value = record.quantity;
+    const unit = record.unit;
+    const convertedValue = convertToKilograms(value, unit);
+    const formattedUnit = formatUnit(unit);
+    return `${convertedValue} ${formattedUnit}`;
+  };
+
   return (
     <List {...props} title="ProductList">
       <Datagrid expand={NutritionDetails}>
@@ -22,8 +60,10 @@ export const ProductList = (props: ListProps) => {
         <TextField source="nameFr" fullWidth />
         <TextField source="code" />
         <NumberField source="price" />
-        <NumberField source="quantity" />
-        <TextField source="unit" />
+        <FunctionField
+          label="Quantity"
+          render={(record: any) => convertAndFormatValue(record)}
+        />
         <BooleanField source="isArchived" />
         <TextField source="upc" />
         <UrlField source="sourceLink" />

--- a/admin-ui/src/Products/ProductList.tsx
+++ b/admin-ui/src/Products/ProductList.tsx
@@ -8,12 +8,44 @@ import {
   ReferenceManyField,
   SingleFieldList,
   TextField,
+  FunctionField,
   UrlField,
 } from "react-admin";
 import { ListField } from "../ListField";
 import { NutritionShow } from "../Nutrition/NutritionShow";
 
 export const ProductList = (props: ListProps) => {
+  const convertToKilograms = (value: number, unit: string) => {
+    if (unit === "g") {
+      return (value / 1000).toFixed(2);
+    } else if (unit === "lb") {
+      return (value / 2.2).toFixed(2);
+    } else {
+      return value;
+    }
+  };
+
+  const convertToLiters = (value: number, unit: string) => {
+    if (unit === "ml" || unit === "mL") {
+      return value / 1000;
+    } else if (unit === "oz") {
+      return value * 0.0295735;
+    } else {
+      return value;
+    }
+  };
+
+  const formatUnit = (unit: string) => {
+    const unitMapping: Record<string, string> = {
+      g: "kg",
+      lb: "kg",
+      ml: "L",
+      mL: "L",
+      oz: "L",
+    };
+    return unitMapping[unit] || unit;
+  };
+
   return (
     <List {...props} title="ProductList">
       <Datagrid expand={NutritionDetails}>
@@ -22,8 +54,23 @@ export const ProductList = (props: ListProps) => {
         <TextField source="nameFr" fullWidth />
         <TextField source="code" />
         <NumberField source="price" />
-        <NumberField source="quantity" />
-        <TextField source="unit" />
+        <FunctionField
+          label="Quantity"
+          render={(record: any) => {
+            const convertedQuantity =
+              record.unit === "g" || record.unit === "lb"
+                ? convertToKilograms(record.quantity, record.unit)
+                : convertToLiters(record.quantity, record.unit);
+
+            return `${convertedQuantity}`;
+          }}
+        />
+        <FunctionField
+          label="Unit"
+          render={(record: any) => {
+            return formatUnit(record.unit);
+          }}
+        />
         <BooleanField source="isArchived" />
         <TextField source="upc" />
         <UrlField source="sourceLink" />


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
I implemented the feature to convert the units which were in gram(g), and pound(lb) to kilogram(kg). And keeping the kilogram(kg) as is. And millilitre(mL), ounce(oz) to litre(L). And keeping the litre(L) as is.

**Previous behaviour**
The products were displayed in various units such as gram(g), kilogram(kg), pound(lb), millilitre(mL), litre(L), ounce(oz), etc. It is very difficult to convert these units while extracting the price for the recipes from the measures table.

**New behaviour**
Now all the products are displayed in kilogram(kg) and litre(L).