### PR TITLE
V2 filter meal plan 437 

### DIFF
--- a/backend/006-meal-plan.sql
+++ b/backend/006-meal-plan.sql
@@ -36,6 +36,12 @@ create or replace function app.set_meal_plan_new_person_id() returns trigger as 
   end;
   $$ language plpgsql;
 
+-- returns set of meal plan tags
+create or replace function app.all_meal_plan_tags() returns SETOF text as $$
+  select distinct unnest(tags) AS tag FROM app.meal_plan;
+ $$ language sql stable;
+comment on function app.all_meal_plan_tags() is 'Unique tags from all meal plans';
+
 create trigger tg_meal_plan_set_app_user_person_id before insert
   on app.meal_plan
   for each row execute procedure app.set_meal_plan_new_person_id();
@@ -44,6 +50,7 @@ create index idx_meal_plan_person_id on app.meal_plan(person_id);
 
 GRANT select, insert, delete, update on app.meal_plan to app_user, app_meal_designer, app_admin;
 GRANT usage on SEQUENCE app.meal_plan_id_seq to app_user, app_meal_designer, app_admin;
+grant execute on function app.all_meal_plan_tags() to app_anonymous, app_user, app_meal_designer, app_admin;
 
 alter table app.meal_plan enable row level security;
 

--- a/backend/006-meal-plan.sql
+++ b/backend/006-meal-plan.sql
@@ -36,11 +36,6 @@ create or replace function app.set_meal_plan_new_person_id() returns trigger as 
   end;
   $$ language plpgsql;
 
--- returns set of meal plan tags
-create or replace function app.all_meal_plan_tags() returns SETOF text as $$
-  select distinct unnest(tags) AS tag FROM app.meal_plan;
- $$ language sql stable;
-comment on function app.all_meal_plan_tags() is 'Unique tags from all meal plans';
 
 create trigger tg_meal_plan_set_app_user_person_id before insert
   on app.meal_plan
@@ -50,7 +45,6 @@ create index idx_meal_plan_person_id on app.meal_plan(person_id);
 
 GRANT select, insert, delete, update on app.meal_plan to app_user, app_meal_designer, app_admin;
 GRANT usage on SEQUENCE app.meal_plan_id_seq to app_user, app_meal_designer, app_admin;
-grant execute on function app.all_meal_plan_tags() to app_anonymous, app_user, app_meal_designer, app_admin;
 
 alter table app.meal_plan enable row level security;
 

--- a/backend/migrations/006-437-meal-plan-tags.sql
+++ b/backend/migrations/006-437-meal-plan-tags.sql
@@ -1,0 +1,10 @@
+begin;
+create or replace function app.all_meal_plan_tags() returns SETOF text as $$
+  select distinct unnest(tags) as tag from app.meal_plan;
+$$ language sql stable;
+
+COMMENT ON FUNCTION app.all_meal_plan_tags() IS 'Unique tags from all meal plans';
+
+grant execute on function app.all_meal_plan_tags() to app_anonymous, app_user, app_meal_designer, app_admin;
+end;
+commit;

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -24,7 +24,7 @@ import {
   Radio
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
 import { MealPlanNode } from "../../state/types";
@@ -81,9 +81,9 @@ const mealPlansQuery = graphql`
     }
     allMealPlanTags(first:10) {
       edges {
-        node
+      node
       }
-    }
+  } 
   }
 `;
 
@@ -209,22 +209,17 @@ export const MealPlans = () => {
   const [searched, setSearched] = useState<string>("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchType, setSearchType] = useState('name');
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const refresh = useCallback(() => {
+    setFetchKey(prevFetchKey => prevFetchKey + 1);
+  }, []);
+
   const data = useLazyLoadQuery<MealPlansQuery>(
     mealPlansQuery,
     {},
-    { fetchPolicy: "network-only" }
+    { fetchPolicy: "network-only", fetchKey }
   );
-
-  const options=[
-    "vegetarian",
-    "vegan",
-    "gluten-free",
-    "keto",
-    "paleo",
-    "diary-free",
-    "egg-free",
-    "nuts-free",
-  ]
 
   const handleTagClick = (tag: string) => {
     if (selectedTags.includes(tag)) {
@@ -233,6 +228,10 @@ export const MealPlans = () => {
       setSelectedTags([...selectedTags, tag]);
     }
   };
+
+  useEffect(() => {
+    refresh();
+  }, [searchType]);
 
   return (
     <div>
@@ -303,16 +302,20 @@ export const MealPlans = () => {
         {searchType === 'tags' &&
             <Grid container direction="column" margin="0rem 2rem">
               <div>
-              {options.map((option, index) => (
-                <Chip
-                  key={index}
-                  label={option}
-                  clickable
-                  color={selectedTags.includes(option) ? "primary" : "default"}
-                  onClick={() => handleTagClick(option)}
-                  onDelete={selectedTags.includes(option) ? () => handleTagClick(option) : undefined}
-                />
-              ))}
+              {data.allMealPlanTags?.edges.map((edge, index) => {
+                const node = edge?.node;
+                if(node !== null) {
+                  return (
+                  <Chip
+                    key={index}
+                    label={node}
+                    clickable
+                    color={selectedTags.includes(node) ? "primary" : "default"}
+                    onClick={() => handleTagClick(node)}
+                    onDelete={selectedTags.includes(node) ? () => handleTagClick(node) : undefined}
+                  />
+                  );
+                }})}
               </div>
             </Grid>
           }

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -79,6 +79,11 @@ const mealPlansQuery = graphql`
         }
       }
     }
+    allMealPlanTags(first:10) {
+      edges {
+        node
+      }
+    }
   }
 `;
 


### PR DESCRIPTION
Describe the technical changes contained in this PR
To add a filter, I modified MealPlans.tsx file under mealplanner-ui folder and added radio buttons. I also created meal-plan-tags.sql file under migrations folder and defined a query allMealPlanTags() which returns the set of existing meal plan tags.

Previous behaviour
The current MealPlanner UI consists of a search bar with which users can search for meal plans based on their names.

New behaviour
Along with the search by name feature, favorites and filter by tags radio buttons are added to the UI. With the filter mealplan feature, users can filter the meal plans based on the tags with an 'AND' relation. Any number of tags can be selected at once, and meal plans will be filtered if and only if all the chosen tags are available in the meal plan. If there are any additional tags, mealplan will still appear in the list.

Related issues addressed by this PR
Fixes https://github.com/CivicTechFredericton/mealplanner/issues/437

Have the following been addressed?

- [ ]  Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?