### PR TITLE
517 filter by tags for meals

### DIFF
--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:4000',
+        target: 'http://127.0.0.1:4000',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
       },

--- a/backend/migrations/006-516-favorite-meal.sql
+++ b/backend/migrations/006-516-favorite-meal.sql
@@ -4,10 +4,9 @@ CREATE TABLE IF NOT EXISTS app.favorite_meals (
     meal_id BIGINT NOT NULL REFERENCES app.meal(id),
     person_id BIGINT REFERENCES app.person(id),
     created_at TIMESTAMP DEFAULT NOW() NOT NULL,
-    updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+    updated_at TIMESTAMP DEFAULT NOW() NOT NULL,
+    UNIQUE (meal_id, person_id)
 );
-
-
 
 -- Create triggers to set created_at and updated_at timestamps
 CREATE OR REPLACE TRIGGER tg_favorite_meals_set_updated_at BEFORE UPDATE
@@ -29,7 +28,7 @@ CREATE POLICY user_favorite_meals ON app.favorite_meals for all to app_user
 USING (person_id = nullif(current_setting('jwt.claims.person_id', true), '')::BIGINT);
 
 -- Function to add a meal plan to favorites
-CREATE OR REPLACE FUNCTION app.create_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION app.add_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
 BEGIN
     -- Fetch the person_id from the current session
     INSERT INTO app.favorite_meals (meal_id, person_id)
@@ -39,7 +38,7 @@ $$ LANGUAGE plpgsql;
 
 
 -- Function to delete a meal plan from favorites
-CREATE OR REPLACE FUNCTION app.delete_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION app.remove_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
 DECLARE
     person_id_param BIGINT;
 BEGIN

--- a/backend/migrations/006-favorite-meal.sql
+++ b/backend/migrations/006-favorite-meal.sql
@@ -1,0 +1,59 @@
+BEGIN;
+CREATE TABLE IF NOT EXISTS app.favorite_meals (
+    id BIGSERIAL PRIMARY KEY,
+    meal_id BIGINT NOT NULL REFERENCES app.meal(id),
+    person_id BIGINT REFERENCES app.person(id),
+    created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP DEFAULT NOW() NOT NULL
+);
+
+
+
+-- Create triggers to set created_at and updated_at timestamps
+CREATE OR REPLACE TRIGGER tg_favorite_meals_set_updated_at BEFORE UPDATE
+ON app.favorite_meals 
+FOR EACH ROW EXECUTE PROCEDURE app.set_updated_at();
+
+CREATE OR REPLACE TRIGGER tg_favorite_meals_set_created_at BEFORE INSERT
+ON app.favorite_meals 
+FOR EACH ROW EXECUTE PROCEDURE app.set_created_at();
+
+-- Create row level security to enable only to view current user favorite meals
+ALTER TABLE app.favorite_meals ENABLE ROW LEVEL SECURITY;
+--An admin will be able to view/create/update favorite meals for any user
+CREATE POLICY admin_favorite_meals ON app.favorite_meals for all to app_admin using(true);
+--A meal designer will be able to view/create/update favorite meals for any user
+CREATE POLICY meal_designer_favorite_meals ON app.favorite_meals for all to app_meal_designer using(true);
+--A user will only be able to view/create/update only if he/she/they are the current logged in user
+CREATE POLICY user_favorite_meals ON app.favorite_meals for all to app_user
+USING (person_id = nullif(current_setting('jwt.claims.person_id', true), '')::BIGINT);
+
+-- Function to add a meal plan to favorites
+CREATE OR REPLACE FUNCTION app.create_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
+BEGIN
+    -- Fetch the person_id from the current session
+    INSERT INTO app.favorite_meals (meal_id, person_id)
+    SELECT meal_id_param, NULLIF(current_setting('jwt.claims.person_id', true), '')::BIGINT;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Function to delete a meal plan from favorites
+CREATE OR REPLACE FUNCTION app.delete_favorite_meal(meal_id_param BIGINT) RETURNS VOID AS $$
+DECLARE
+    person_id_param BIGINT;
+BEGIN
+    -- Fetch the person_id from the current session
+    person_id_param := NULLIF(current_setting('jwt.claims.person_id', true), '')::BIGINT;
+
+    -- Delete from favorite_meals table based on meal_id and person_id
+    DELETE FROM app.favorite_meals
+    WHERE meal_id = meal_id_param AND person_id = person_id_param;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Grant execute permission to appropriate roles
+GRANT select, insert, delete, update on app.favorite_meals to app_user, app_meal_designer, app_admin;
+GRANT usage on SEQUENCE app.favorite_meals_id_seq to app_user, app_meal_designer, app_admin;
+
+COMMIT;

--- a/backend/migrations/007-516-nanoid-postgres.sql
+++ b/backend/migrations/007-516-nanoid-postgres.sql
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Viascom Ltd liab. Co
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- The `nanoid()` function generates a compact, URL-friendly unique identifier.
+-- Based on the given size and alphabet, it creates a randomized string that's ideal for
+-- use-cases requiring small, unpredictable IDs (e.g., URL shorteners, generated file names, etc.).
+-- While it comes with a default configuration, the function is designed to be flexible,
+-- allowing for customization to meet specific needs.
+DROP FUNCTION IF EXISTS nanoid(int, text, float);
+CREATE OR REPLACE FUNCTION nanoid(
+    size int DEFAULT 21, -- The number of symbols in the NanoId String. Must be greater than 0.
+    alphabet text DEFAULT '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', -- The symbols used in the NanoId String. Must contain between 1 and 255 symbols.
+    additionalBytesFactor float DEFAULT 1.6 -- The additional bytes factor used for calculating the step size. Must be equal or greater then 1.
+)
+    RETURNS text -- A randomly generated NanoId String
+    LANGUAGE plpgsql
+    VOLATILE
+    LEAKPROOF
+    PARALLEL SAFE
+AS
+$$
+DECLARE
+    alphabetArray  text[];
+    alphabetLength int := 64;
+    mask           int := 63;
+    step           int := 34;
+BEGIN
+    IF size IS NULL OR size < 1 THEN
+        RAISE EXCEPTION 'The size must be defined and greater than 0!';
+    END IF;
+
+    IF alphabet IS NULL OR length(alphabet) = 0 OR length(alphabet) > 255 THEN
+        RAISE EXCEPTION 'The alphabet can''t be undefined, zero or bigger than 255 symbols!';
+    END IF;
+
+    IF additionalBytesFactor IS NULL OR additionalBytesFactor < 1 THEN
+        RAISE EXCEPTION 'The additional bytes factor can''t be less than 1!';
+    END IF;
+
+    alphabetArray := regexp_split_to_array(alphabet, '');
+    alphabetLength := array_length(alphabetArray, 1);
+    mask := (2 << cast(floor(log(alphabetLength - 1) / log(2)) as int)) - 1;
+    step := cast(ceil(additionalBytesFactor * mask * size / alphabetLength) AS int);
+
+    IF step > 1024 THEN
+        step := 1024; -- The step size % can''t be bigger then 1024!
+    END IF;
+
+    RETURN nanoid_optimized(size, alphabet, mask, step);
+END
+$$;
+
+-- Generates an optimized random string of a specified size using the given alphabet, mask, and step.
+-- This optimized version is designed for higher performance and lower memory overhead.
+-- No checks are performed! Use it only if you really know what you are doing.
+DROP FUNCTION IF EXISTS nanoid_optimized(int, text, int, int);
+CREATE OR REPLACE FUNCTION nanoid_optimized(
+    size int, -- The desired length of the generated string.
+    alphabet text, -- The set of characters to choose from for generating the string.
+    mask int, -- The mask used for mapping random bytes to alphabet indices. Should be `(2^n) - 1` where `n` is a power of 2 less than or equal to the alphabet size.
+    step int -- The number of random bytes to generate in each iteration. A larger value may speed up the function but increase memory usage.
+)
+    RETURNS text -- A randomly generated NanoId String
+    LANGUAGE plpgsql
+    VOLATILE
+    LEAKPROOF
+    PARALLEL SAFE
+AS
+$$
+DECLARE
+    idBuilder      text := '';
+    counter        int  := 0;
+    bytes          bytea;
+    alphabetIndex  int;
+    alphabetArray  text[];
+    alphabetLength int  := 64;
+BEGIN
+    alphabetArray := regexp_split_to_array(alphabet, '');
+    alphabetLength := array_length(alphabetArray, 1);
+
+    LOOP
+        bytes := gen_random_bytes(step);
+        FOR counter IN 0..step - 1
+            LOOP
+                alphabetIndex := (get_byte(bytes, counter) & mask) + 1;
+                IF alphabetIndex <= alphabetLength THEN
+                    idBuilder := idBuilder || alphabetArray[alphabetIndex];
+                    IF length(idBuilder) = size THEN
+                        RETURN idBuilder;
+                    END IF;
+                END IF;
+            END LOOP;
+    END LOOP;
+END
+$$;

--- a/backend/migrations/007-517-meal-tags.sql
+++ b/backend/migrations/007-517-meal-tags.sql
@@ -1,0 +1,10 @@
+begin;
+create or replace function app.all_meal_tags() returns SETOF text as $$
+  select distinct unnest(tags) as tag from app.meal;
+$$ language sql stable;
+
+COMMENT ON FUNCTION app.all_meal_tags() IS 'Unique tags from all meals';
+
+grant execute on function app.all_meal_tags() to app_user, app_meal_designer, app_admin;
+end;
+commit;

--- a/backend/migrations/008-516-add-slug-to-person.sql
+++ b/backend/migrations/008-516-add-slug-to-person.sql
@@ -1,0 +1,19 @@
+-- Need to have a route user-slug/favorites for mealplans and meals
+-- to list user favorites
+BEGIN;
+ALTER TABLE app.person 
+    ADD COLUMN slug TEXT NOT NULL DEFAULT nanoid(10);
+
+CREATE UNIQUE INDEX idx_person_slug
+    ON app.person (slug);
+COMMIT;
+
+alter type app.current_user add attribute slug text;
+
+--  Current person is updated with slug
+create or replace function app.current_person() returns app.current_user as $$
+    select app.person.id, app.person.role::text, app.person.email, 
+           app.person.full_name, app.person.slug
+    from app.person
+    where id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint
+  $$ language sql stable security definer;

--- a/mealplanner-ui/package.json
+++ b/mealplanner-ui/package.json
@@ -78,5 +78,5 @@
     "@types/react-relay": "^13.0.1",
     "@types/relay-runtime": "^13.0.1"
   },
-  "proxy": "http://localhost:4000"
+  "proxy": "http://127.0.0.1:4000"
 }

--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -13,6 +13,7 @@ import { Meals } from "./pages/Meals/Meals";
 import { ShoppingList } from "./pages/ShoppingList";
 import environment from "./relay/environment";
 import { fetchCurrentPerson, initState } from "./state/state";
+import { FavoriteMeals } from "./pages/Meals/PersonFavoriteMeals";
 
 const theme = createTheme({
   palette: {
@@ -41,8 +42,6 @@ const theme = createTheme({
 //Initializing local state from state.ts
 initState();
 
-//fetchCurrentPerson();
-
 function App() {
   let [intialized, setInitialized] = useState(false);
   useEffect(() => {
@@ -53,6 +52,7 @@ function App() {
   if (!intialized) {
     return <h1>loading...</h1>;
   }
+  
   return (
     <RelayEnvironmentProvider environment={environment}>
       <ThemeProvider theme={theme}>
@@ -104,6 +104,16 @@ function App() {
                 <Suspense fallback={"loading inner..."}>
                   <LoggedIn>
                     <Meal />
+                  </LoggedIn>
+                </Suspense>
+              }
+            />
+            <Route 
+              path={`/meals/:slug/favorites`}
+              element={
+                <Suspense fallback={"loading favorite meals.."}>
+                  <LoggedIn>
+                    <FavoriteMeals />
                   </LoggedIn>
                 </Suspense>
               }

--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -10,9 +10,11 @@ import {
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
 import { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
+import { RefetchFnDynamic, useLazyLoadQuery } from "react-relay";
 import { createMealPlan } from "../../state/state";
 import { CreateMealPlanAllUsersQuery } from "./__generated__/CreateMealPlanAllUsersQuery.graphql";
+import { OperationType } from "relay-runtime";
+import { MealPlansQuery$data } from "./__generated__/MealPlansQuery.graphql";
 
 const query = graphql`
   query CreateMealPlanAllUsersQuery {
@@ -31,7 +33,7 @@ type userType = {
   id: number;
 };
 
-export const CreateMealPlan = ({ connection }: { connection: string }) => {
+export const CreateMealPlan = ({ connection, refetch }: { connection: string, refetch: RefetchFnDynamic<OperationType, MealPlansQuery$data> }) => {
   const [open, setOpen] = useState(false);
 
   const users = useLazyLoadQuery<CreateMealPlanAllUsersQuery>(query, {});
@@ -199,6 +201,8 @@ export const CreateMealPlan = ({ connection }: { connection: string }) => {
                 tags: tags,
                 connections: [connection],
               }).then(() => {
+                console.log('refetching tags');
+                refetch({}, {fetchPolicy: "network-only"});
                 handleClose();
               });
             }}

--- a/mealplanner-ui/src/pages/MealPlans/DeleteMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/DeleteMealPlan.tsx
@@ -18,15 +18,21 @@ const deleteMealPlanGQL = graphql`
 `;
 
 export const deleteMealPlan = (connection: string, id: string) => {
-  commitMutation(environment, {
-    mutation: deleteMealPlanGQL,
-    variables: {
-      connections: [connection],
-      mealPlanId: id.toString(),
-    },
-    onCompleted(response, errors) {
-      console.log(response);
-      console.log(errors);
-    },
+  return new Promise((res, rej) => {
+    commitMutation(environment, {
+      mutation: deleteMealPlanGQL,
+      variables: {
+        connections: [connection],
+        mealPlanId: id.toString(),
+      },
+      onCompleted(response, errors) {
+        if (!errors) {
+          res(response);
+          return;
+        }
+        rej(errors);
+      },
+    });
   });
+  
 };

--- a/mealplanner-ui/src/pages/MealPlans/FavoriteMeals.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/FavoriteMeals.tsx
@@ -1,0 +1,63 @@
+import { graphql } from "babel-plugin-relay/macro";
+import { useLazyLoadQuery } from "react-relay";
+import { useParams } from "react-router-dom";
+import { FavoriteMealsQuery, FavoriteMealsQuery$data } from "./__generated__/FavoriteMealsQuery.graphql";
+import React from "react";
+import { Grid } from "@mui/material";
+import { MealCard } from "../Meals/Meals";
+
+const favoriteMealsQuery = graphql`
+  query FavoriteMealsQuery($currentUserId: BigInt) {
+      favoriteMeals(orderBy: [CREATED_AT_DESC], 
+                    first: 1000, 
+                    filter: { personId: {equalTo: $currentUserId} } ) {
+        nodes {
+            id
+            rowId
+            meal {
+              rowId
+              nameEn
+              nameFr
+              descriptionEn
+              descriptionFr
+              categories
+              tags
+              code
+              photoUrl
+              videoUrl
+            }
+      }
+      }
+  }
+`;
+
+export const FavoriteMeals = () => {
+  
+  let favMealsData = useLazyLoadQuery<FavoriteMealsQuery>(
+    favoriteMealsQuery,
+    {currentUserId: "1"},
+    {fetchPolicy: "store-and-network"}
+    )
+ const favMeals = favMealsData.favoriteMeals?.nodes;
+  
+  return (
+    <React.Fragment>
+      { favMeals ? (
+        <Grid
+          container
+          spacing={2}
+          justifyContent="center"
+          marginTop="1rem"
+          columns={4}
+        >
+          {favMeals.map((favMeal) => {
+            if (favMeal.meal?.nameEn.toLowerCase())
+              return <MealCard node={favMeal.meal} />;
+          })}
+        </Grid>
+      ) : (
+        "No meals"
+      )}
+    </React.Fragment>
+  )
+}

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { MealPlanNode } from "../../state/types";
+import { Avatar, Card, CardActions, CardContent, CardHeader, Collapse, Grid, IconButton, IconButtonProps, ImageList, ImageListItem, Typography, styled } from "@mui/material";
+import { ShoppingCart, DeleteTwoTone, ContentCopy, ExpandMore, Favorite } from "@mui/icons-material";
+import { useNavigate } from "react-router";
+import { getCurrentPerson } from "../../state/state";
+import { deleteMealPlan } from "./DeleteMealPlan";
+import { duplicateMealPlan } from "./DuplicateMealPlan";
+import { RefetchFnDynamic } from "react-relay";
+import { OperationType } from "relay-runtime";
+import { MealPlansQuery$data } from "./__generated__/MealPlansQuery.graphql";
+
+interface MealPlanCardProps {
+    mealplan: MealPlanNode;
+    connection: string;
+    refetch: RefetchFnDynamic<OperationType, MealPlansQuery$data>;
+  }
+
+  interface ExpandMoreProps extends IconButtonProps {
+    expand: boolean;
+  }
+  
+  const ExpandMoreFn = styled((props: ExpandMoreProps) => {
+    const { expand, ...other } = props;
+    return <IconButton {...other} />;
+  })(({ theme, expand }) => ({
+    transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
+    marginLeft: "auto",
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  }));
+  
+const getInitials = (name: string) => {
+    let initials = "";
+    let names: string[] = (name && name.length > 1 && name.split(" ")) || [
+      "No",
+      "Name",
+    ];
+    names.forEach((n) => {
+      initials += n[0];
+    });
+    return initials;
+  };
+
+export const MealPlanCard = (props: MealPlanCardProps) => {
+    const [expanded, setExpanded] = React.useState(false);
+    const navigate = useNavigate();
+    const mealplan = props.mealplan;
+    const connection = props.connection;
+    const handleExpandClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setExpanded(!expanded);
+    };
+  
+    return (
+      <Grid item xs="auto">
+        <Card
+          sx={{ maxWidth: 332 }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(`/mealplans/${mealplan.rowId}`);
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.cursor = "pointer";
+          }}
+        >
+          <CardHeader
+            avatar={
+              <Avatar sx={{ bgcolor: "green", width: "fit" }} aria-label="user">
+                {getInitials(mealplan.person?.fullName || "")}
+              </Avatar>
+            }
+            action={
+              <div>
+                <IconButton
+                  aria-label="shopping list"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log("stopped propagation");
+                    navigate(`/mealplans/${mealplan.rowId}/shopping-list`);
+                  }}
+                >
+                  <ShoppingCart />
+                </IconButton>
+                <IconButton
+                  aria-label="delete"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log("meal plan id: ", typeof mealplan.rowId);
+                    deleteMealPlan(connection, mealplan.rowId).then(() => {
+                      //refetch here for fetching tags after delete
+                      props.refetch({}, {fetchPolicy: "network-only"})
+                    })
+                  }}
+                >
+                  <DeleteTwoTone />
+                </IconButton>
+                {getCurrentPerson().personRole === "app_admin" || getCurrentPerson().personRole === "app_meal_designer" ? (
+                  <IconButton
+                    aria-label="duplicate"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      duplicateMealPlan(connection, mealplan.rowId);
+                    }}
+                  >
+                    <ContentCopy />
+                  </IconButton>
+                ):null}
+              </div>
+            }
+            title={mealplan.nameEn}
+            subheader={mealplan.person?.fullName}
+          />
+          <ImageList sx={{ width: 350, height: 150 }} cols={3} rowHeight={164}>
+            {mealplan.mealPlanEntries.nodes.map((meal) =>
+              meal.meal?.photoUrl !== null ? (
+                <ImageListItem key={meal.meal?.id}>
+                  <img
+                    src={`${meal.meal?.photoUrl}`}
+                    srcSet={`${meal.meal?.photoUrl}`}
+                    alt={meal.meal?.photoUrl || "no image"}
+                    loading="lazy"
+                  />
+                </ImageListItem>
+              ) : (
+                <></>
+              )
+            )}
+          </ImageList>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              {mealplan.tags?.map((tag) => (
+                <span>{tag} &nbsp;</span>
+              ))}
+            </Typography>
+          </CardContent>
+          <CardActions disableSpacing>
+          <IconButton aria-label="add to favorites">
+              <Favorite />
+            </IconButton>
+  
+            <ExpandMoreFn
+              expand={expanded}
+              onClick={handleExpandClick}
+              aria-expanded={expanded}
+              aria-label="show more"
+            >
+              <ExpandMore />
+            </ExpandMoreFn>
+          </CardActions>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <CardContent>
+              <Typography>
+                {" "}
+                <div>{mealplan.descriptionEn}</div>
+              </Typography>
+            </CardContent>
+          </Collapse>
+        </Card>
+      </Grid>
+    );
+  };

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -1,4 +1,4 @@
-import { DeleteTwoTone, Search, ShoppingCart, ContentCopy } from "@mui/icons-material";
+import { ContentCopy, DeleteTwoTone, ShoppingCart } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
@@ -8,30 +8,29 @@ import {
   CardContent,
   CardHeader,
   Collapse,
+  FormControl,
+  FormControlLabel,
   Grid,
   IconButton,
   IconButtonProps,
   ImageList,
   ImageListItem,
   InputBase,
-  Paper,
-  styled,
-  Typography,
-  Chip,
-  FormControl,
+  Radio,
   RadioGroup,
-  FormControlLabel,
-  Radio
+  Typography,
+  styled
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
+import { getCurrentPerson } from "../../state/state";
 import { MealPlanNode } from "../../state/types";
 import { CreateMealPlan } from "./CreateMealPlan";
 import { deleteMealPlan } from "./DeleteMealPlan";
 import { duplicateMealPlan } from "./DuplicateMealPlan";
-import {getCurrentPerson} from "../../state/state";
+import { MealPlansTags } from "./MealPlansTags";
 import { MealPlansQuery } from "./__generated__/MealPlansQuery.graphql";
 
 interface ExpandMoreProps extends IconButtonProps {
@@ -81,13 +80,15 @@ const mealPlansQuery = graphql`
         }
       }
     }
-    allMealPlanTags(first:10) {
-      edges {
-      node
-      }
-  } 
+    # fragment name from MealPlansTags
+    ...MealPlansTags_tags
+    gqLocalState {
+      selectedMealPlanTags
+    }
   }
 `;
+
+
 
 const getInitials = (name: string) => {
   let initials = "";
@@ -220,31 +221,14 @@ const MealPlanCard = (props: MealPlanCardProps) => {
 
 export const MealPlans = () => {
   const [searched, setSearched] = useState<string>("");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchType, setSearchType] = useState('name');
-  const [fetchKey, setFetchKey] = useState(0);
-
-  const refresh = useCallback(() => {
-    setFetchKey(prevFetchKey => prevFetchKey + 1);
-  }, []);
 
   const data = useLazyLoadQuery<MealPlansQuery>(
     mealPlansQuery,
     {},
-    { fetchPolicy: "network-only", fetchKey }
+    { fetchPolicy: "network-only" }
   );
-
-  const handleTagClick = (tag: string) => {
-    if (selectedTags.includes(tag)) {
-      setSelectedTags(selectedTags.filter(item => item !== tag));
-    } else {
-      setSelectedTags([...selectedTags, tag]);
-    }
-  };
-
-  useEffect(() => {
-    refresh();
-  }, [searchType]);
+  const selectedTags = data.gqLocalState.selectedMealPlanTags || [];
 
   return (
     <div>
@@ -313,25 +297,8 @@ export const MealPlans = () => {
         </span>
         </Grid>
         {searchType === 'tags' &&
-            <Grid container direction="column" margin="0rem 2rem">
-              <div>
-              {data.allMealPlanTags?.edges.map((edge, index) => {
-                const node = edge?.node;
-                if(node !== null) {
-                  return (
-                  <Chip
-                    key={index}
-                    label={node}
-                    clickable
-                    color={selectedTags.includes(node) ? "primary" : "default"}
-                    onClick={() => handleTagClick(node)}
-                    onDelete={selectedTags.includes(node) ? () => handleTagClick(node) : undefined}
-                  />
-                  );
-                }})}
-              </div>
-            </Grid>
-          }
+            <MealPlansTags tags={data}/>
+        }
       {data.mealPlans ? (
         <Grid container spacing={2} margin="1rem" columns={4}>
           {data.mealPlans?.edges.map(({ node }) => {

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -1,57 +1,20 @@
-import { ContentCopy, DeleteTwoTone, ShoppingCart } from "@mui/icons-material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
-  Avatar,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
   FormControl,
   FormControlLabel,
   Grid,
-  IconButton,
-  IconButtonProps,
-  ImageList,
-  ImageListItem,
   InputBase,
   Radio,
-  RadioGroup,
-  Typography,
-  styled
+  RadioGroup
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
-import { useNavigate } from "react-router";
-import { getCurrentPerson } from "../../state/state";
-import { MealPlanNode } from "../../state/types";
+import { Suspense, useState } from "react";
+import { useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import { CreateMealPlan } from "./CreateMealPlan";
-import { deleteMealPlan } from "./DeleteMealPlan";
-import { duplicateMealPlan } from "./DuplicateMealPlan";
-import { MealPlansTags } from "./MealPlansTags";
+import { MealPlanCard } from "./MealPlanCard";
+import { MealPlansTags, MealPlansTagsFragment } from "./MealPlansTags";
 import { MealPlansQuery } from "./__generated__/MealPlansQuery.graphql";
 
-interface ExpandMoreProps extends IconButtonProps {
-  expand: boolean;
-}
 
-const ExpandMore = styled((props: ExpandMoreProps) => {
-  const { expand, ...other } = props;
-  return <IconButton {...other} />;
-})(({ theme, expand }) => ({
-  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
-  marginLeft: "auto",
-  transition: theme.transitions.create("transform", {
-    duration: theme.transitions.duration.shortest,
-  }),
-}));
-
-interface MealPlanCardProps {
-  mealplan: MealPlanNode;
-  connection: string;
-}
 
 const mealPlansQuery = graphql`
   query MealPlansQuery {
@@ -88,137 +51,6 @@ const mealPlansQuery = graphql`
   }
 `;
 
-
-
-const getInitials = (name: string) => {
-  let initials = "";
-  let names: string[] = (name && name.length > 1 && name.split(" ")) || [
-    "No",
-    "Name",
-  ];
-  names.forEach((n) => {
-    initials += n[0];
-  });
-  return initials;
-};
-
-const MealPlanCard = (props: MealPlanCardProps) => {
-  const [expanded, setExpanded] = React.useState(false);
-  const navigate = useNavigate();
-  const mealplan = props.mealplan;
-  const connection = props.connection;
-  const handleExpandClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setExpanded(!expanded);
-  };
-
-  return (
-    <Grid item xs="auto">
-      <Card
-        sx={{ maxWidth: 332 }}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          navigate(`/mealplans/${mealplan.rowId}`);
-        }}
-        onMouseOver={(e) => {
-          e.currentTarget.style.cursor = "pointer";
-        }}
-      >
-        <CardHeader
-          avatar={
-            <Avatar sx={{ bgcolor: "green", width: "fit" }} aria-label="user">
-              {getInitials(mealplan.person?.fullName || "")}
-            </Avatar>
-          }
-          action={
-            <div>
-              <IconButton
-                aria-label="shopping list"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log("stopped propagation");
-                  navigate(`/mealplans/${mealplan.rowId}/shopping-list`);
-                }}
-              >
-                <ShoppingCart />
-              </IconButton>
-              <IconButton
-                aria-label="delete"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log("meal plan id: ", typeof mealplan.rowId);
-                  deleteMealPlan(connection, mealplan.rowId);
-                }}
-              >
-                <DeleteTwoTone />
-              </IconButton>
-              {getCurrentPerson().personRole === "app_admin" || getCurrentPerson().personRole === "app_meal_designer" ? (
-                <IconButton
-                  aria-label="duplicate"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    duplicateMealPlan(connection, mealplan.rowId);
-                  }}
-                >
-                  <ContentCopy />
-                </IconButton>
-              ):null}
-            </div>
-          }
-          title={mealplan.nameEn}
-          subheader={mealplan.person?.fullName}
-        />
-        <ImageList sx={{ width: 350, height: 150 }} cols={3} rowHeight={164}>
-          {mealplan.mealPlanEntries.nodes.map((meal) =>
-            meal.meal?.photoUrl !== null ? (
-              <ImageListItem key={meal.meal?.id}>
-                <img
-                  src={`${meal.meal?.photoUrl}`}
-                  srcSet={`${meal.meal?.photoUrl}`}
-                  alt={meal.meal?.photoUrl || "no image"}
-                  loading="lazy"
-                />
-              </ImageListItem>
-            ) : (
-              <></>
-            )
-          )}
-        </ImageList>
-        <CardContent>
-          <Typography variant="body2" color="text.secondary">
-            {mealplan.tags?.map((tag) => (
-              <span>{tag} &nbsp;</span>
-            ))}
-          </Typography>
-        </CardContent>
-        <CardActions disableSpacing>
-        <IconButton aria-label="add to favorites">
-            <FavoriteIcon />
-          </IconButton>
-
-          <ExpandMore
-            expand={expanded}
-            onClick={handleExpandClick}
-            aria-expanded={expanded}
-            aria-label="show more"
-          >
-            <ExpandMoreIcon />
-          </ExpandMore>
-        </CardActions>
-        <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <CardContent>
-            <Typography>
-              {" "}
-              <div>{mealplan.descriptionEn}</div>
-            </Typography>
-          </CardContent>
-        </Collapse>
-      </Card>
-    </Grid>
-  );
-};
-
 export const MealPlans = () => {
   const [searched, setSearched] = useState<string>("");
   const [searchType, setSearchType] = useState('name');
@@ -228,6 +60,9 @@ export const MealPlans = () => {
     {},
     { fetchPolicy: "network-only" }
   );
+
+  const [_, refetch] = useRefetchableFragment(MealPlansTagsFragment, data);
+  
   const selectedTags = data.gqLocalState.selectedMealPlanTags || [];
 
   return (
@@ -290,14 +125,16 @@ export const MealPlans = () => {
         </FormControl>
         <span>
         {data.mealPlans ? (
-          <CreateMealPlan connection={data.mealPlans?.__id} />
+          <CreateMealPlan connection={data.mealPlans?.__id} refetch={refetch}  />
         ) : (
           <></>
         )}
         </span>
         </Grid>
         {searchType === 'tags' &&
+          <Suspense fallback={"loading tags..."}>
             <MealPlansTags tags={data}/>
+          </Suspense>
         }
       {data.mealPlans ? (
         <Grid container spacing={2} margin="1rem" columns={4}>
@@ -306,6 +143,7 @@ export const MealPlans = () => {
               return (
                 <MealPlanCard
                   mealplan={node}
+                  refetch={refetch}
                   connection={data.mealPlans!.__id}
                 />
               );

--- a/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
@@ -1,59 +1,66 @@
-import { Chip, Grid } from "@mui/material";
+import { Chip, Grid, Stack } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
 import { useFragment } from "react-relay";
 import { MealPlansTags_tags$key } from "./__generated__/MealPlansTags_tags.graphql";
 import { setSelectedMealPlanTags } from "../../state/state";
 
-const MealPlansTagsFragment = graphql`
-  fragment MealPlansTags_tags on Query{
-    gqLocalState {
-      selectedMealPlanTags
-    }
-    allMealPlanTags(first:100) {
-      edges {
-        node
-      }
-    }
-  }
-`
-
-export const MealPlansTags = ({tags}:{tags: MealPlansTags_tags$key}) => {
-    const mptags = useFragment(MealPlansTagsFragment, tags);
-    // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
-    // When it returns a null, we need to assign an empty array.
-    const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
-    const handleTagClick = (node: string) => {
-        // if tag does not exist, add to the GQLocalState
-        if(!selectedMPTags.includes(node)) {
-            const selectedTags = selectedMPTags.concat([node])
-            setSelectedMealPlanTags(selectedTags);
-            return;
+export const MealPlansTagsFragment = graphql`
+  fragment MealPlansTags_tags on Query
+    @refetchable(queryName: "MealPlansTagsRefetchQuery") {
+        gqLocalState {
+            selectedMealPlanTags
         }
-        // if tag exists, remove from the GQLocalState
-        const index = selectedMPTags.indexOf(node);
-        let selectedTags = [...selectedMPTags];
-        selectedTags.splice(index, 1);
-        setSelectedMealPlanTags(selectedTags);
-    }
+        allMealPlanTags(first:100) {
+            edges {
+                node
+            }
+        }
+  }
+`;
 
-    return (
-        <Grid container direction="column" margin="0rem 2rem">
-              <div>
-              {mptags.allMealPlanTags?.edges.map((edge, index) => {
-                const node = edge?.node;
-                if(node !== null) {
-                  return (
-                  <Chip
-                    key={index}
-                    label={node}
-                    clickable
-                    color={selectedMPTags.includes(node) ? "primary" : "default"}
-                    onClick={() => handleTagClick(node)}
-                    onDelete={selectedMPTags.includes(node) ? () => handleTagClick(node) : undefined}
-                  />
-                  );
-                }})}
-              </div>
-        </Grid>
-    )
-}
+export const MealPlansTags = ({ tags }: { tags: MealPlansTags_tags$key }) => {
+  const mptags = useFragment(MealPlansTagsFragment, tags);
+  // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
+  // When it returns a null, we need to assign an empty array.
+  const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
+  const handleTagClick = (node: string) => {
+    // if tag does not exist, add to the GQLocalState
+    if (!selectedMPTags.includes(node)) {
+      const selectedTags = selectedMPTags.concat([node]);
+      setSelectedMealPlanTags(selectedTags);
+      return;
+    }
+    // if tag exists, remove from the GQLocalState
+    const index = selectedMPTags.indexOf(node);
+    let selectedTags = [...selectedMPTags];
+    selectedTags.splice(index, 1);
+    setSelectedMealPlanTags(selectedTags);
+  };
+
+  return (
+    <Grid container direction="column" margin="0rem 2rem">
+      <Stack direction="row" spacing={1}>
+        {mptags.allMealPlanTags?.edges.map((edge, index) => {
+          const node = edge?.node;
+          if (node !== null) {
+            return (
+            
+              <Chip
+                key={index}
+                label={node}
+                clickable
+                color={selectedMPTags.includes(node) ? "primary" : "default"}
+                onClick={() => handleTagClick(node)}
+                onDelete={
+                  selectedMPTags.includes(node)
+                    ? () => handleTagClick(node)
+                    : undefined
+                }
+              />
+            );
+          }
+        })}
+      </Stack>
+    </Grid>
+  );
+};

--- a/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
@@ -1,0 +1,59 @@
+import { Chip, Grid } from "@mui/material";
+import { graphql } from "babel-plugin-relay/macro";
+import { useFragment } from "react-relay";
+import { MealPlansTags_tags$key } from "./__generated__/MealPlansTags_tags.graphql";
+import { setSelectedMealPlanTags } from "../../state/state";
+
+const MealPlansTagsFragment = graphql`
+  fragment MealPlansTags_tags on Query{
+    gqLocalState {
+      selectedMealPlanTags
+    }
+    allMealPlanTags(first:100) {
+      edges {
+        node
+      }
+    }
+  }
+`
+
+export const MealPlansTags = ({tags}:{tags: MealPlansTags_tags$key}) => {
+    const mptags = useFragment(MealPlansTagsFragment, tags);
+    // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
+    // When it returns a null, we need to assign an empty array.
+    const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
+    const handleTagClick = (node: string) => {
+        // if tag does not exist, add to the GQLocalState
+        if(!selectedMPTags.includes(node)) {
+            const selectedTags = selectedMPTags.concat([node])
+            setSelectedMealPlanTags(selectedTags);
+            return;
+        }
+        // if tag exists, remove from the GQLocalState
+        const index = selectedMPTags.indexOf(node);
+        let selectedTags = [...selectedMPTags];
+        selectedTags.splice(index, 1);
+        setSelectedMealPlanTags(selectedTags);
+    }
+
+    return (
+        <Grid container direction="column" margin="0rem 2rem">
+              <div>
+              {mptags.allMealPlanTags?.edges.map((edge, index) => {
+                const node = edge?.node;
+                if(node !== null) {
+                  return (
+                  <Chip
+                    key={index}
+                    label={node}
+                    clickable
+                    color={selectedMPTags.includes(node) ? "primary" : "default"}
+                    onClick={() => handleTagClick(node)}
+                    onDelete={selectedMPTags.includes(node) ? () => handleTagClick(node) : undefined}
+                  />
+                  );
+                }})}
+              </div>
+        </Grid>
+    )
+}

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/FavoriteMealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/FavoriteMealsQuery.graphql.ts
@@ -1,0 +1,280 @@
+/**
+ * @generated SignedSource<<0a80130f9602ba00ce83fc41418e0b6c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type CategoryT = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK" | "%future added value";
+export type FavoriteMealsQuery$variables = {
+  currentUserId?: any | null;
+};
+export type FavoriteMealsQuery$data = {
+  readonly favoriteMeals: {
+    readonly nodes: ReadonlyArray<{
+      readonly id: string;
+      readonly rowId: any;
+      readonly meal: {
+        readonly rowId: any;
+        readonly nameEn: string;
+        readonly nameFr: string | null;
+        readonly descriptionEn: string | null;
+        readonly descriptionFr: string | null;
+        readonly categories: ReadonlyArray<CategoryT | null> | null;
+        readonly tags: ReadonlyArray<string | null> | null;
+        readonly code: string;
+        readonly photoUrl: string | null;
+        readonly videoUrl: string | null;
+      } | null;
+    }>;
+  } | null;
+};
+export type FavoriteMealsQuery = {
+  variables: FavoriteMealsQuery$variables;
+  response: FavoriteMealsQuery$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "currentUserId"
+  }
+],
+v1 = [
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "equalTo",
+            "variableName": "currentUserId"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "personId"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1000
+  },
+  {
+    "kind": "Literal",
+    "name": "orderBy",
+    "value": [
+      "CREATED_AT_DESC"
+    ]
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rowId",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nameEn",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nameFr",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "descriptionEn",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "descriptionFr",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "categories",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "tags",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "photoUrl",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "videoUrl",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FavoriteMealsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FavoriteMealsConnection",
+        "kind": "LinkedField",
+        "name": "favoriteMeals",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FavoriteMeal",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Meal",
+                "kind": "LinkedField",
+                "name": "meal",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FavoriteMealsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FavoriteMealsConnection",
+        "kind": "LinkedField",
+        "name": "favoriteMeals",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FavoriteMeal",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Meal",
+                "kind": "LinkedField",
+                "name": "meal",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0ec3c20581dc2be5ab0c0b40e22c04f1",
+    "id": null,
+    "metadata": {},
+    "name": "FavoriteMealsQuery",
+    "operationKind": "query",
+    "text": "query FavoriteMealsQuery(\n  $currentUserId: BigInt\n) {\n  favoriteMeals(orderBy: [CREATED_AT_DESC], first: 1000, filter: {personId: {equalTo: $currentUserId}}) {\n    nodes {\n      id\n      rowId\n      meal {\n        rowId\n        nameEn\n        nameFr\n        descriptionEn\n        descriptionFr\n        categories\n        tags\n        code\n        photoUrl\n        videoUrl\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "13e7833a027612ae19b09e5b1798b9cd";
+
+export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ead987bd34bf3d8205f8e719987dbb8>>
+ * @generated SignedSource<<0d4ecb7881c90ff7427254017ffa9bcc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,6 +33,11 @@ export type MealPlansQuery$data = {
           }>;
         };
       };
+    }>;
+  } | null;
+  readonly allMealPlanTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null;
     }>;
   } | null;
 };
@@ -161,7 +166,42 @@ v11 = {
     }
   ]
 },
-v12 = [
+v12 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 10
+    }
+  ],
+  "concreteType": "AllMealPlanTagsConnection",
+  "kind": "LinkedField",
+  "name": "allMealPlanTags",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AllMealPlanTagEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "node",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "allMealPlanTags(first:10)"
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -254,7 +294,8 @@ return {
           (v11/*: any*/)
         ],
         "storageKey": "__connection_mealPlans_connection(orderBy:[\"CREATED_AT_DESC\"])"
-      }
+      },
+      (v12/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -267,7 +308,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "concreteType": "MealPlansConnection",
         "kind": "LinkedField",
         "name": "mealPlans",
@@ -346,7 +387,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "filters": [
           "orderBy"
         ],
@@ -354,11 +395,12 @@ return {
         "key": "connection_mealPlans",
         "kind": "LinkedHandle",
         "name": "mealPlans"
-      }
+      },
+      (v12/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "1c433e426b71dc78259ad06b4394d55d",
+    "cacheID": "fcbaa0ecfbd9bdcc0c61a5f021f371ce",
     "id": null,
     "metadata": {
       "connection": [
@@ -374,11 +416,11 @@ return {
     },
     "name": "MealPlansQuery",
     "operationKind": "query",
-    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  allMealPlanTags(first: 10) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a8120207cca27b22c9e92fea33cdf3ff";
+(node as any).hash = "a1e54bccdb2beda284bb48b6b3b8c78c";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ead987bd34bf3d8205f8e719987dbb8>>
+ * @generated SignedSource<<3849a6d3c82c32401fbea5af0aa1917b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type MealPlansQuery$variables = {};
 export type MealPlansQuery$data = {
   readonly mealPlans: {
@@ -35,6 +36,10 @@ export type MealPlansQuery$data = {
       };
     }>;
   } | null;
+  readonly gqLocalState: {
+    readonly selectedMealPlanTags: ReadonlyArray<string> | null;
+  };
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
 };
 export type MealPlansQuery = {
   variables: MealPlansQuery$variables;
@@ -161,7 +166,30 @@ v11 = {
     }
   ]
 },
-v12 = [
+v12 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GQLocalState",
+      "kind": "LinkedField",
+      "name": "gqLocalState",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "selectedMealPlanTags",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -254,7 +282,13 @@ return {
           (v11/*: any*/)
         ],
         "storageKey": "__connection_mealPlans_connection(orderBy:[\"CREATED_AT_DESC\"])"
-      }
+      },
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealPlansTags_tags"
+      },
+      (v12/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -267,7 +301,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "concreteType": "MealPlansConnection",
         "kind": "LinkedField",
         "name": "mealPlans",
@@ -346,7 +380,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "filters": [
           "orderBy"
         ],
@@ -354,11 +388,47 @@ return {
         "key": "connection_mealPlans",
         "kind": "LinkedHandle",
         "name": "mealPlans"
-      }
+      },
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealPlanTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealPlanTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealPlanTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealPlanTags(first:100)"
+      },
+      (v12/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "1c433e426b71dc78259ad06b4394d55d",
+    "cacheID": "5a880ca0cdd8fd42e200cf9e45a3554b",
     "id": null,
     "metadata": {
       "connection": [
@@ -374,11 +444,11 @@ return {
     },
     "name": "MealPlansQuery",
     "operationKind": "query",
-    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a8120207cca27b22c9e92fea33cdf3ff";
+(node as any).hash = "6db72941db50511d305c9cb41483d7bb";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTagsRefetchQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTagsRefetchQuery.graphql.ts
@@ -1,0 +1,116 @@
+/**
+ * @generated SignedSource<<c634920cfebd8f560eea5e9750914240>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealPlansTagsRefetchQuery$variables = {};
+export type MealPlansTagsRefetchQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
+};
+export type MealPlansTagsRefetchQuery = {
+  variables: MealPlansTagsRefetchQuery$variables;
+  response: MealPlansTagsRefetchQuery$data;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MealPlansTagsRefetchQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealPlansTags_tags"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MealPlansTagsRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealPlanTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealPlanTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealPlanTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealPlanTags(first:100)"
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "GQLocalState",
+            "kind": "LinkedField",
+            "name": "gqLocalState",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "selectedMealPlanTags",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17379b146ec46e9b2f502cd8bfe3a545",
+    "id": null,
+    "metadata": {},
+    "name": "MealPlansTagsRefetchQuery",
+    "operationKind": "query",
+    "text": "query MealPlansTagsRefetchQuery {\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "3511bb24130d79d02ff559004c9b7492";
+
+export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd1afa085b409d6e60f2ba71919820e7>>
+ * @generated SignedSource<<7a58edcf14ed094536bfa2cc0e0a6578>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type MealPlansTags_tags$data = {
   readonly gqLocalState: {
@@ -29,7 +29,13 @@ export type MealPlansTags_tags$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./MealPlansTagsRefetchQuery.graphql')
+    }
+  },
   "name": "MealPlansTags_tags",
   "selections": [
     {
@@ -95,6 +101,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "77d5522adf80567a53a300e40d8e1dcf";
+(node as any).hash = "3511bb24130d79d02ff559004c9b7492";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
@@ -1,0 +1,100 @@
+/**
+ * @generated SignedSource<<fd1afa085b409d6e60f2ba71919820e7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealPlansTags_tags$data = {
+  readonly gqLocalState: {
+    readonly selectedMealPlanTags: ReadonlyArray<string> | null;
+  };
+  readonly allMealPlanTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null;
+    }>;
+  } | null;
+  readonly " $fragmentType": "MealPlansTags_tags";
+};
+export type MealPlansTags_tags$key = {
+  readonly " $data"?: MealPlansTags_tags$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MealPlansTags_tags",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AllMealPlanTagsConnection",
+      "kind": "LinkedField",
+      "name": "allMealPlanTags",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AllMealPlanTagEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "node",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "allMealPlanTags(first:100)"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "GQLocalState",
+          "kind": "LinkedField",
+          "name": "gqLocalState",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "selectedMealPlanTags",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "77d5522adf80567a53a300e40d8e1dcf";
+
+export default node;

--- a/mealplanner-ui/src/pages/Meals/MealCard.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealCard.tsx
@@ -1,7 +1,6 @@
-import { useTheme } from "@emotion/react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
-import { Grid, Card, CardHeader, CardMedia, CardContent, Typography, CardActions, IconButton, Collapse, IconButtonProps, styled } from "@mui/material";
+import { useTheme, Grid, Card, CardHeader, CardMedia, CardContent, Typography, CardActions, IconButton, Collapse, IconButtonProps, styled } from "@mui/material";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { MealNode } from "../../state/types";
@@ -34,7 +33,7 @@ export const MealCard = (props: MealProps) => {
     const theme = useTheme();
     const tagStyle = {
       color: "white",
-      backgroundColor: "primary",
+      backgroundColor: `${theme.palette.primary.dark}`,
       padding: "0 0.5em",
       borderRadius: "1em",
       margin: "0.3em 0",

--- a/mealplanner-ui/src/pages/Meals/MealCard.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealCard.tsx
@@ -1,0 +1,103 @@
+import { useTheme } from "@emotion/react";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+import { Grid, Card, CardHeader, CardMedia, CardContent, Typography, CardActions, IconButton, Collapse, IconButtonProps, styled } from "@mui/material";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { MealNode } from "../../state/types";
+
+interface ExpandMoreProps extends IconButtonProps {
+    expand: boolean;
+  }
+  
+  const ExpandMoreFn = styled((props: ExpandMoreProps) => {
+    const { expand, ...other } = props;
+    return <IconButton {...other} />;
+  })(({ theme, expand }) => ({
+    transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
+    marginLeft: "auto",
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  }));
+  
+type MealProps = { node: MealNode };
+  
+export const MealCard = (props: MealProps) => {
+    const [expanded, setExpanded] = React.useState(false);
+    const meal = props.node;
+    const navigate = useNavigate();
+    const handleExpandClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setExpanded(!expanded);
+    };
+    const theme = useTheme();
+    const tagStyle = {
+      color: "white",
+      backgroundColor: "primary",
+      padding: "0 0.5em",
+      borderRadius: "1em",
+      margin: "0.3em 0",
+      display: "inline-block",
+    };
+    return (
+      <Grid item xs="auto">
+        <Card
+          sx={{ width: 300 }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(`/meals/${meal.rowId}`);
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.cursor = "pointer";
+          }}
+        >
+          <CardHeader
+            action={<div></div>}
+            title={meal.nameEn}
+            subheader={meal.nameFr}
+          />
+          <CardMedia
+            component="img"
+            height="194"
+            image={meal.photoUrl || "/images/Logo_Meal.png"}
+            alt={meal.nameEn}
+            style={{ objectFit: meal.photoUrl ? "cover" : "contain" }}
+          />
+          <CardContent>
+            <Typography variant="body2" color="text.secondary" lineHeight="2rem">
+              {meal.tags?.map((tag) => (
+                <span>
+                  <span style={tagStyle}>{tag}</span>
+                  &nbsp;
+                </span>
+              ))}
+            </Typography>
+          </CardContent>
+          <CardActions disableSpacing>
+            <IconButton aria-label="add to favorites">
+              <FavoriteIcon />
+            </IconButton>
+            <ExpandMoreFn
+              expand={expanded}
+              onClick={handleExpandClick}
+              aria-expanded={expanded}
+              aria-label="show more"
+            >
+              <ExpandMoreIcon />
+            </ExpandMoreFn>
+          </CardActions>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <CardContent>
+              <Typography>
+                {" "}
+                <div>{meal.descriptionEn}</div>
+                <div>{meal.descriptionFr}</div>
+              </Typography>
+            </CardContent>
+          </Collapse>
+        </Card>
+      </Grid>
+    );
+  };

--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -1,0 +1,65 @@
+import { Chip, Grid, Stack } from "@mui/material";
+import { graphql } from "babel-plugin-relay/macro";
+import { useFragment } from "react-relay";
+import { MealTags_tags$key } from "./__generated__/MealTags_tags.graphql";
+import { setSelectedMealTags } from "../../state/state";
+
+export const MealTagsFragment = graphql`
+  fragment MealTags_tags on Query
+    @refetchable(queryName: "MealTagsRefetchQuery") {
+        gqLocalState {
+            selectedMealTags
+        }
+        allMealTags(first:100) {
+            edges {
+                node
+            }
+        }
+  }
+`;
+
+export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
+  const mealTags = useFragment(MealTagsFragment, tags);
+  // If nothing is selected, mealTags.gqLocalState.selectedMealTags will return a null
+  // When it returns a null, we need to assign an empty array.
+  const selectedMTags = mealTags.gqLocalState.selectedMealTags || [];
+  const handleTagClick = (node: string) => {
+    // if tag does not exist, add to the GQLocalState
+    if (!selectedMTags.includes(node)) {
+      const selectedTags = selectedMTags.concat([node]);
+      setSelectedMealTags(selectedTags);
+      return;
+    }
+    // if tag exists, remove from the GQLocalState
+    const index = selectedMTags.indexOf(node);
+    let selectedTags = [...selectedMTags];
+    selectedTags.splice(index, 1);
+    setSelectedMealTags(selectedTags);
+  };
+
+  return (
+    <Grid container direction="column" margin="0rem 2rem">
+      <Stack direction="row" spacing={1}>
+        {mealTags.allMealTags?.edges.map((edge, index) => {
+          const node = edge?.node;
+          if (node !== null && node !==undefined) {
+            return (
+              <Chip
+                key={index}
+                label={node}
+                clickable
+                color={selectedMTags.includes(node) ? "primary" : "default"}
+                onClick={() => handleTagClick(node)}
+                onDelete={
+                  selectedMTags.includes(node)
+                    ? () => handleTagClick(node)
+                    : undefined
+                }
+              />
+            );
+          }
+        })}
+      </Stack>
+    </Grid>
+   );
+};

--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -1,12 +1,15 @@
-import { Search } from "@mui/icons-material";
 import {
+  FormControl,
+  FormControlLabel,
   Grid,
   InputBase,
-  Paper
+  Radio,
+  RadioGroup
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
+import {Suspense, useState } from "react";
+import { useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { MealTags, MealTagsFragment } from "./MealTags";
 import { MealsQuery } from "./__generated__/MealsQuery.graphql";
 import { MealCard } from "./MealCard";
 
@@ -26,59 +29,101 @@ const mealsQuery = graphql`
         videoUrl
       }
     }
+    # fragment name from MealTags
+    ...MealTags_tags
+    gqLocalState {
+      selectedMealTags
+    }
   }
 `;
 
-
-
 export const Meals = () => {
   const [searchMeal, setSearchMeal] = useState<string>("");
+  const [searchType, setSearchType] = useState('name');
+
   const data = useLazyLoadQuery<MealsQuery>(
     mealsQuery,
     {},
     { fetchPolicy: "store-or-network" }
   );
+
+  const selectedTags = data.gqLocalState.selectedMealTags || [];
+
   return (
+    <div>
     <Grid
       container
       spacing={2}
       columns={2}
-      justifyContent="center"
-      marginTop="1rem"
+      gap="2rem"
+      margin="1rem 2rem"
+      width="95%"
+      justifyContent="space-between"
     >
-      <Paper
-        component="form"
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          width: "75%",
-          justifyContent: "center",
+      <FormControl component="fieldset">
+      <RadioGroup
+        row
+        aria-label="searchType"
+        name="searchType"
+        value={searchType}
+        onChange={(e) => {
+          setSearchType(e.target.value);
         }}
       >
-        <InputBase
-          sx={{ ml: 1, flex: 1 }}
-          placeholder="Search Meal"
-          inputProps={{ "aria-label": "Search Meal" }}
-          onChange={(e) => setSearchMeal(e.target.value.toLowerCase())}
+       <FormControlLabel
+          value="name"
+          control={
+            <Radio 
+              checked={searchType === 'name'}
+            />
+          }
+          label={
+            <InputBase
+              placeholder="Search Meal"
+              inputProps={{ "aria-label": "Search Meal" }}
+              readOnly={searchType !== 'name'}
+              value={searchMeal}
+              onChange={(e) => {
+                if (searchType === 'name') {
+                  setSearchMeal(e.target.value.toLowerCase());
+                }
+              }}
+              style={{ cursor: 'text',
+                      borderBottom: '1px solid black', width: '40vw' }}
+              />
+          }
         />
-        <Search />
-      </Paper>
-      {data.meals ? (
-        <Grid
-          container
-          spacing={2}
-          justifyContent="center"
-          marginTop="1rem"
-          columns={4}
-        >
-          {data.meals?.nodes.map((node) => {
-            if (node.nameEn.toLowerCase().includes(searchMeal))
-              return <MealCard node={node} />;
-          })}
-        </Grid>
+        <FormControlLabel
+          value="favorites"
+          control={<Radio />}
+          label="Favorites"
+          checked={searchType === 'favorites'}
+        />
+        <FormControlLabel
+          value="tags"
+          control={<Radio />}
+          label="Tags"
+          checked={searchType === 'tags'}
+        /> 
+      </RadioGroup>
+    </FormControl>
+    </Grid>
+      {searchType === 'tags' &&
+        <Suspense fallback={"loading tags..."}>
+        <MealTags tags={data}/>
+      </Suspense>
+    }
+   
+    {data.meals ? (
+      <Grid container spacing={2} margin="1rem" columns={4}>
+        {data.meals?.nodes.map((node) => {
+      if ((searchType === 'name' && node.nameEn.toLowerCase().includes(searchMeal)) || (searchType === 'tags' && selectedTags.every(tag => node.tags?.includes(tag)))) {
+        return <MealCard node={node} />
+    }})}
+  </Grid>
       ) : (
         "No meals"
       )}
-    </Grid>
+    </div>
   );
 };

--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -1,28 +1,14 @@
 import { Search } from "@mui/icons-material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  CardMedia,
-  Collapse,
   Grid,
-  IconButton,
-  IconButtonProps,
   InputBase,
-  Paper,
-  styled,
-  Typography,
-  useTheme,
+  Paper
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useState } from "react";
+import { useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
-import { useNavigate } from "react-router";
-import { MealNode } from "../../state/types";
 import { MealsQuery } from "./__generated__/MealsQuery.graphql";
+import { MealCard } from "./MealCard";
 
 const mealsQuery = graphql`
   query MealsQuery {
@@ -43,101 +29,8 @@ const mealsQuery = graphql`
   }
 `;
 
-interface ExpandMoreProps extends IconButtonProps {
-  expand: boolean;
-}
 
-const ExpandMore = styled((props: ExpandMoreProps) => {
-  const { expand, ...other } = props;
-  return <IconButton {...other} />;
-})(({ theme, expand }) => ({
-  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
-  marginLeft: "auto",
-  transition: theme.transitions.create("transform", {
-    duration: theme.transitions.duration.shortest,
-  }),
-}));
 
-type MealProps = { node: MealNode };
-
-const MealCard = (props: MealProps) => {
-  const [expanded, setExpanded] = React.useState(false);
-  const meal = props.node;
-  const navigate = useNavigate();
-  const handleExpandClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setExpanded(!expanded);
-  };
-  const theme = useTheme();
-  const tagStyle = {
-    color: "white",
-    backgroundColor: `${theme.palette.primary.main}`,
-    padding: "0 0.5em",
-    borderRadius: "1em",
-    margin: "0.3em 0",
-    display: "inline-block",
-  };
-  return (
-    <Grid item xs="auto">
-      <Card
-        sx={{ width: 300 }}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          navigate(`/meals/${meal.rowId}`);
-        }}
-        onMouseOver={(e) => {
-          e.currentTarget.style.cursor = "pointer";
-        }}
-      >
-        <CardHeader
-          action={<div></div>}
-          title={meal.nameEn}
-          subheader={meal.nameFr}
-        />
-        <CardMedia
-          component="img"
-          height="194"
-          image={meal.photoUrl || "/images/Logo_Meal.png"}
-          alt={meal.nameEn}
-          style={{ objectFit: meal.photoUrl ? "cover" : "contain" }}
-        />
-        <CardContent>
-          <Typography variant="body2" color="text.secondary" lineHeight="2rem">
-            {meal.tags?.map((tag) => (
-              <span>
-                <span style={tagStyle}>{tag}</span>
-                &nbsp;
-              </span>
-            ))}
-          </Typography>
-        </CardContent>
-        <CardActions disableSpacing>
-          <IconButton aria-label="add to favorites">
-            <FavoriteIcon />
-          </IconButton>
-          <ExpandMore
-            expand={expanded}
-            onClick={handleExpandClick}
-            aria-expanded={expanded}
-            aria-label="show more"
-          >
-            <ExpandMoreIcon />
-          </ExpandMore>
-        </CardActions>
-        <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <CardContent>
-            <Typography>
-              {" "}
-              <div>{meal.descriptionEn}</div>
-              <div>{meal.descriptionFr}</div>
-            </Typography>
-          </CardContent>
-        </Collapse>
-      </Card>
-    </Grid>
-  );
-};
 export const Meals = () => {
   const [searchMeal, setSearchMeal] = useState<string>("");
   const data = useLazyLoadQuery<MealsQuery>(

--- a/mealplanner-ui/src/pages/Meals/PersonFavoriteMeals.tsx
+++ b/mealplanner-ui/src/pages/Meals/PersonFavoriteMeals.tsx
@@ -1,20 +1,22 @@
 import { graphql } from "babel-plugin-relay/macro";
 import { useLazyLoadQuery } from "react-relay";
-import { useParams } from "react-router-dom";
-import { FavoriteMealsQuery, FavoriteMealsQuery$data } from "./__generated__/FavoriteMealsQuery.graphql";
 import React from "react";
 import { Grid } from "@mui/material";
-import { MealCard } from "../Meals/Meals";
+import { MealCard } from "./MealCard";
+import { useParams } from "react-router-dom";
+import { PersonFavoriteMealsQuery } from "./__generated__/PersonFavoriteMealsQuery.graphql";
 
 const favoriteMealsQuery = graphql`
-  query FavoriteMealsQuery($currentUserId: BigInt) {
-      favoriteMeals(orderBy: [CREATED_AT_DESC], 
-                    first: 1000, 
-                    filter: { personId: {equalTo: $currentUserId} } ) {
+  query PersonFavoriteMealsQuery($slug: String!){
+  people (
+    filter: {slug: {equalTo: $slug}}, 
+    first: 1
+  ) 
+  {
+    nodes {
+      favoriteMeals {
         nodes {
-            id
-            rowId
-            meal {
+          meal {
               rowId
               nameEn
               nameFr
@@ -25,20 +27,25 @@ const favoriteMealsQuery = graphql`
               code
               photoUrl
               videoUrl
-            }
+          }
+        }
       }
-      }
+    }
   }
+}
 `;
 
 export const FavoriteMeals = () => {
-  
-  let favMealsData = useLazyLoadQuery<FavoriteMealsQuery>(
+  const params = useParams();
+  let favMealsData = useLazyLoadQuery<PersonFavoriteMealsQuery>(
     favoriteMealsQuery,
-    {currentUserId: "1"},
+    {slug: params.slug as string},
     {fetchPolicy: "store-and-network"}
     )
- const favMeals = favMealsData.favoriteMeals?.nodes;
+ const favMeals = favMealsData.people?.nodes[0].favoriteMeals.nodes;
+ favMeals?.map(favMeal => {
+  console.log('fav Meals', favMeal.meal);
+ })
   
   return (
     <React.Fragment>

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealTagsRefetchQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealTagsRefetchQuery.graphql.ts
@@ -1,0 +1,116 @@
+/**
+ * @generated SignedSource<<51c63abb7c226ddc0171801ae0d1fa9f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealTagsRefetchQuery$variables = Record<PropertyKey, never>;
+export type MealTagsRefetchQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
+};
+export type MealTagsRefetchQuery = {
+  response: MealTagsRefetchQuery$data;
+  variables: MealTagsRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MealTagsRefetchQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealTags_tags"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MealTagsRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealTags(first:100)"
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "GQLocalState",
+            "kind": "LinkedField",
+            "name": "gqLocalState",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "selectedMealTags",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "90fe2e40edfaecc1092afc28bac5a7bf",
+    "id": null,
+    "metadata": {},
+    "name": "MealTagsRefetchQuery",
+    "operationKind": "query",
+    "text": "query MealTagsRefetchQuery {\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "97df7621ff4ba64d426d7d0c0d4659a2";
+
+export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealTags_tags.graphql.ts
@@ -1,0 +1,106 @@
+/**
+ * @generated SignedSource<<72218c9242b191257a80348b3e262521>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealTags_tags$data = {
+  readonly allMealTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null | undefined;
+    }>;
+  } | null | undefined;
+  readonly gqLocalState: {
+    readonly selectedMealTags: ReadonlyArray<string> | null | undefined;
+  };
+  readonly " $fragmentType": "MealTags_tags";
+};
+export type MealTags_tags$key = {
+  readonly " $data"?: MealTags_tags$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./MealTagsRefetchQuery.graphql')
+    }
+  },
+  "name": "MealTags_tags",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AllMealTagsConnection",
+      "kind": "LinkedField",
+      "name": "allMealTags",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AllMealTagEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "node",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "allMealTags(first:100)"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "GQLocalState",
+          "kind": "LinkedField",
+          "name": "gqLocalState",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "selectedMealTags",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "97df7621ff4ba64d426d7d0c0d4659a2";
+
+export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09041e94dc85ca5b10bee8ed6546d1ab>>
+ * @generated SignedSource<<cfb8ec032e2e32784428e0a0387e651b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,27 +9,32 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type CategoryT = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK" | "%future added value";
-export type MealsQuery$variables = {};
+import { FragmentRefs } from "relay-runtime";
+export type CategoryT = "BREAKFAST" | "DINNER" | "LUNCH" | "SNACK" | "%future added value";
+export type MealsQuery$variables = Record<PropertyKey, never>;
 export type MealsQuery$data = {
+  readonly gqLocalState: {
+    readonly selectedMealTags: ReadonlyArray<string> | null | undefined;
+  };
   readonly meals: {
     readonly nodes: ReadonlyArray<{
-      readonly rowId: any;
-      readonly nameEn: string;
-      readonly nameFr: string | null;
-      readonly descriptionEn: string | null;
-      readonly descriptionFr: string | null;
-      readonly categories: ReadonlyArray<CategoryT | null> | null;
-      readonly tags: ReadonlyArray<string | null> | null;
+      readonly categories: ReadonlyArray<CategoryT | null | undefined> | null | undefined;
       readonly code: string;
-      readonly photoUrl: string | null;
-      readonly videoUrl: string | null;
+      readonly descriptionEn: string | null | undefined;
+      readonly descriptionFr: string | null | undefined;
+      readonly nameEn: string;
+      readonly nameFr: string | null | undefined;
+      readonly photoUrl: string | null | undefined;
+      readonly rowId: any;
+      readonly tags: ReadonlyArray<string | null | undefined> | null | undefined;
+      readonly videoUrl: string | null | undefined;
     }>;
   } | null;
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
 };
 export type MealsQuery = {
-  variables: MealsQuery$variables;
   response: MealsQuery$data;
+  variables: MealsQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -116,6 +121,29 @@ v10 = {
   "kind": "ScalarField",
   "name": "videoUrl",
   "storageKey": null
+},
+v11 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GQLocalState",
+      "kind": "LinkedField",
+      "name": "gqLocalState",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "selectedMealTags",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
 };
 return {
   "fragment": {
@@ -155,7 +183,13 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealTags_tags"
+      },
+      (v11/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -204,20 +238,56 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealTags(first:100)"
+      },
+      (v11/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "146cfbf3599982b9e1159ae65c60f39a",
+    "cacheID": "b149ff8b3d1086e08138a1a3d52387d5",
     "id": null,
     "metadata": {},
     "name": "MealsQuery",
     "operationKind": "query",
-    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n}\n"
+    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d3ce343b40931b542f7a72303f4e7f26";
+(node as any).hash = "53d8f93b61dc92a420009b86c5baff5a";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09041e94dc85ca5b10bee8ed6546d1ab>>
+ * @generated SignedSource<<2402e5bbc5b7cd8ee62da53fa5263e56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,11 @@ export type MealsQuery$data = {
       readonly code: string;
       readonly photoUrl: string | null;
       readonly videoUrl: string | null;
+    }>;
+  } | null;
+  readonly allMealTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null;
     }>;
   } | null;
 };
@@ -116,6 +121,41 @@ v10 = {
   "kind": "ScalarField",
   "name": "videoUrl",
   "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 10
+    }
+  ],
+  "concreteType": "AllMealTagsConnection",
+  "kind": "LinkedField",
+  "name": "allMealTags",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AllMealTagEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "node",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "allMealTags(first:10)"
 };
 return {
   "fragment": {
@@ -155,7 +195,8 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      (v11/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -204,20 +245,21 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      (v11/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "146cfbf3599982b9e1159ae65c60f39a",
+    "cacheID": "d671063f5586b491ffcd3913b199e9c1",
     "id": null,
     "metadata": {},
     "name": "MealsQuery",
     "operationKind": "query",
-    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n}\n"
+    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n  allMealTags(first: 10) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d3ce343b40931b542f7a72303f4e7f26";
+(node as any).hash = "c614abe3034413feeb361f859e1e3557";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/PersonFavoriteMealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/PersonFavoriteMealsQuery.graphql.ts
@@ -1,0 +1,317 @@
+/**
+ * @generated SignedSource<<863e4f7623c52ed299a04003dc69fe9a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type CategoryT = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK" | "%future added value";
+export type PersonFavoriteMealsQuery$variables = {
+  slug: string;
+};
+export type PersonFavoriteMealsQuery$data = {
+  readonly people: {
+    readonly nodes: ReadonlyArray<{
+      readonly favoriteMeals: {
+        readonly nodes: ReadonlyArray<{
+          readonly meal: {
+            readonly rowId: any;
+            readonly nameEn: string;
+            readonly nameFr: string | null;
+            readonly descriptionEn: string | null;
+            readonly descriptionFr: string | null;
+            readonly categories: ReadonlyArray<CategoryT | null> | null;
+            readonly tags: ReadonlyArray<string | null> | null;
+            readonly code: string;
+            readonly photoUrl: string | null;
+            readonly videoUrl: string | null;
+          } | null;
+        }>;
+      };
+    }>;
+  } | null;
+};
+export type PersonFavoriteMealsQuery = {
+  variables: PersonFavoriteMealsQuery$variables;
+  response: PersonFavoriteMealsQuery$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug"
+  }
+],
+v1 = [
+  {
+    "fields": [
+      {
+        "fields": [
+          {
+            "kind": "Variable",
+            "name": "equalTo",
+            "variableName": "slug"
+          }
+        ],
+        "kind": "ObjectValue",
+        "name": "slug"
+      }
+    ],
+    "kind": "ObjectValue",
+    "name": "filter"
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rowId",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nameEn",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nameFr",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "descriptionEn",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "descriptionFr",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "categories",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "tags",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "photoUrl",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "videoUrl",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PersonFavoriteMealsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "PeopleConnection",
+        "kind": "LinkedField",
+        "name": "people",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Person",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FavoriteMealsConnection",
+                "kind": "LinkedField",
+                "name": "favoriteMeals",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FavoriteMeal",
+                    "kind": "LinkedField",
+                    "name": "nodes",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Meal",
+                        "kind": "LinkedField",
+                        "name": "meal",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          (v11/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "PersonFavoriteMealsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "PeopleConnection",
+        "kind": "LinkedField",
+        "name": "people",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Person",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FavoriteMealsConnection",
+                "kind": "LinkedField",
+                "name": "favoriteMeals",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FavoriteMeal",
+                    "kind": "LinkedField",
+                    "name": "nodes",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Meal",
+                        "kind": "LinkedField",
+                        "name": "meal",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v10/*: any*/),
+                          (v11/*: any*/),
+                          (v12/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v12/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v12/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d21affdb69a71d5ed6f4333e6ab08a92",
+    "id": null,
+    "metadata": {},
+    "name": "PersonFavoriteMealsQuery",
+    "operationKind": "query",
+    "text": "query PersonFavoriteMealsQuery(\n  $slug: String!\n) {\n  people(filter: {slug: {equalTo: $slug}}, first: 1) {\n    nodes {\n      favoriteMeals {\n        nodes {\n          meal {\n            rowId\n            nameEn\n            nameFr\n            descriptionEn\n            descriptionFr\n            categories\n            tags\n            code\n            photoUrl\n            videoUrl\n            id\n          }\n          id\n        }\n      }\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "8bd68f95d3150b0b19308f64c7cbf00a";
+
+export default node;

--- a/mealplanner-ui/src/state/__generated__/state_CurrentUserQuery.graphql.ts
+++ b/mealplanner-ui/src/state/__generated__/state_CurrentUserQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2a1482329ae00a0a530cc74ec254602e>>
+ * @generated SignedSource<<eb374f6230dfc05fff930e5d69f8506b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,13 +12,11 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 export type state_CurrentUserQuery$variables = {};
 export type state_CurrentUserQuery$data = {
   readonly currentPerson: {
-    readonly person: {
-      readonly id: string;
-      readonly rowId: any;
-    } | null;
+    readonly rowId: any | null;
     readonly email: string | null;
     readonly fullName: string | null;
     readonly role: string | null;
+    readonly slug: string | null;
   } | null;
 };
 export type state_CurrentUserQuery = {
@@ -39,26 +37,8 @@ var v0 = [
       {
         "alias": null,
         "args": null,
-        "concreteType": "Person",
-        "kind": "LinkedField",
-        "name": "person",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "rowId",
-            "storageKey": null
-          }
-        ],
+        "kind": "ScalarField",
+        "name": "rowId",
         "storageKey": null
       },
       {
@@ -80,6 +60,13 @@ var v0 = [
         "args": null,
         "kind": "ScalarField",
         "name": "role",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "slug",
         "storageKey": null
       }
     ],
@@ -104,16 +91,16 @@ return {
     "selections": (v0/*: any*/)
   },
   "params": {
-    "cacheID": "ad6c25c014e537f7be0822a008dc3c59",
+    "cacheID": "e1386ae5cebceca86301ad711b3f6368",
     "id": null,
     "metadata": {},
     "name": "state_CurrentUserQuery",
     "operationKind": "query",
-    "text": "query state_CurrentUserQuery {\n  currentPerson {\n    person {\n      id\n      rowId\n    }\n    email\n    fullName\n    role\n  }\n}\n"
+    "text": "query state_CurrentUserQuery {\n  currentPerson {\n    rowId\n    email\n    fullName\n    role\n    slug\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "658925a637e6c08cf61239a420825299";
+(node as any).hash = "ff00cae081fc66e331b709846013d6d4";
 
 export default node;

--- a/mealplanner-ui/src/state/schema.local.graphql
+++ b/mealplanner-ui/src/state/schema.local.graphql
@@ -17,6 +17,8 @@ type SelectedMeal {
 type CurrentLoggedInUser {
     personID: BigInt!
     personName: String!
+    personRole: String!
+    personSlug: String!
 }
 
 extend type Query {

--- a/mealplanner-ui/src/state/schema.local.graphql
+++ b/mealplanner-ui/src/state/schema.local.graphql
@@ -5,6 +5,7 @@
 type GQLocalState {
     selectedMeal: SelectedMeal
     currentUser: CurrentLoggedInUser
+    selectedMealPlanTags: [String!]
 }
 
 type SelectedMeal {

--- a/mealplanner-ui/src/state/schema.local.graphql
+++ b/mealplanner-ui/src/state/schema.local.graphql
@@ -6,6 +6,7 @@ type GQLocalState {
     selectedMeal: SelectedMeal
     currentUser: CurrentLoggedInUser
     selectedMealPlanTags: [String!]
+    selectedMealTags: [String!]
 }
 
 type SelectedMeal {

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -46,6 +46,13 @@ export const setSelectedMealPlanTags = (mpTags: string[]) => {
   })
 }
 
+export const setSelectedMealTags = (mealTags: string[]) => {
+  commitLocalUpdate(environment, (store) => {
+    const localState = store.get(STATE_ID);
+    localState?.setValue(mealTags, "selectedMealTags");
+  })
+}
+
 export const setSelectedMeal = (meal: SearchedMeal) => {
   commitLocalUpdate(environment, (store) => {
     const localState = store.get(STATE_ID);

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -177,13 +177,11 @@ export const deleteMealFromPlan = (connectionID: string, mpeId: number) => {
 const currentUserQuery = graphql`
   query state_CurrentUserQuery {
     currentPerson {
-      person {
-        id
-        rowId
-      }
+      rowId
       email
       fullName
       role
+      slug
     }
   }
 `;
@@ -204,9 +202,10 @@ function setCurrentUser(data: state_CurrentUserQuery$data | undefined) {
       let localState = store.get(STATE_ID);
       store.delete("client:currentUser");
       let record = store.create("client:currentUser", "CurrentLoggedInUser");
-      record.setValue(data?.currentPerson?.person?.rowId, "personID");
+      record.setValue(data?.currentPerson?.rowId, "personID");
       record.setValue(data?.currentPerson?.fullName, "personName");
       record.setValue(data?.currentPerson?.role, "personRole");
+      record.setValue(data.currentPerson?.slug, "personSlug");
       localState?.setLinkedRecord(record, "currentUser");
     });
   }
@@ -276,16 +275,18 @@ export const getCurrentPerson = (): {
   personID: string;
   personName: string;
   personRole: string;
+  personSlug: string;
 } => {
   const store = environment.getStore();
   let record = store.getSource().get("client:currentUser");
   if (record === null || record === undefined) {
-    return { personID: "", personName: "",personRole: "" };
+    return { personID: "", personName: "",personRole: "", personSlug: "" };
   }
   return {
     personID: record["personID"].toString(),
     personName: record["personName"].toString(),
-    personRole: record["personRole"].toString()
+    personRole: record["personRole"].toString(),
+    personSlug: record["personSlug"].toString(),
   };
 };
 

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -39,6 +39,13 @@ export const initState = () => {
   });
 };
 
+export const setSelectedMealPlanTags = (mpTags: string[]) => {
+  commitLocalUpdate(environment, (store) => {
+    const localState = store.get(STATE_ID);
+    localState?.setValue(mpTags, "selectedMealPlanTags");
+  })
+}
+
 export const setSelectedMeal = (meal: SearchedMeal) => {
   commitLocalUpdate(environment, (store) => {
     const localState = store.get(STATE_ID);


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
To add a filter, I modified Meals.tsx file under mealplanner-ui folder and added radio buttons. I also created meal-tags.sql file under migrations folder and defined a query allMealTags() which returns the set of existing meal tags.

**Previous behaviour**
The current Meals UI consists of a search bar with which users can search for meals based on their names.

**New behaviour**
Along with the search by name feature, favorites and filter by tags radio buttons are added to the UI. With the filter meal feature, users can filter the meal based on the tags with an 'AND' relation. Any number of tags can be selected at once, and meals will be filtered if and only if all the chosen tags are available in the meal. If there are any additional tags, meal will still appear in the list.

**Related issues addressed by this PR**
Fixes #517 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

