### PR TITLE
[#522] filter mealplan tag

### DIFF
--- a/mealplanner-ui/package.json
+++ b/mealplanner-ui/package.json
@@ -78,5 +78,5 @@
     "@types/react-relay": "^13.0.1",
     "@types/relay-runtime": "^13.0.1"
   },
-  "proxy": "http://localhost:4000"
+  "proxy": "http://127.0.0.1:4000"
 }

--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -10,9 +10,11 @@ import {
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
 import { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
+import { RefetchFnDynamic, useLazyLoadQuery } from "react-relay";
 import { createMealPlan } from "../../state/state";
 import { CreateMealPlanAllUsersQuery } from "./__generated__/CreateMealPlanAllUsersQuery.graphql";
+import { OperationType } from "relay-runtime";
+import { MealPlansQuery$data } from "./__generated__/MealPlansQuery.graphql";
 
 const query = graphql`
   query CreateMealPlanAllUsersQuery {
@@ -31,7 +33,7 @@ type userType = {
   id: number;
 };
 
-export const CreateMealPlan = ({ connection }: { connection: string }) => {
+export const CreateMealPlan = ({ connection, refetch }: { connection: string, refetch: RefetchFnDynamic<OperationType, MealPlansQuery$data> }) => {
   const [open, setOpen] = useState(false);
 
   const users = useLazyLoadQuery<CreateMealPlanAllUsersQuery>(query, {});
@@ -199,6 +201,8 @@ export const CreateMealPlan = ({ connection }: { connection: string }) => {
                 tags: tags,
                 connections: [connection],
               }).then(() => {
+                console.log('refetching tags');
+                refetch({}, {fetchPolicy: "network-only"});
                 handleClose();
               });
             }}

--- a/mealplanner-ui/src/pages/MealPlans/DeleteMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/DeleteMealPlan.tsx
@@ -18,15 +18,21 @@ const deleteMealPlanGQL = graphql`
 `;
 
 export const deleteMealPlan = (connection: string, id: string) => {
-  commitMutation(environment, {
-    mutation: deleteMealPlanGQL,
-    variables: {
-      connections: [connection],
-      mealPlanId: id.toString(),
-    },
-    onCompleted(response, errors) {
-      console.log(response);
-      console.log(errors);
-    },
+  return new Promise((res, rej) => {
+    commitMutation(environment, {
+      mutation: deleteMealPlanGQL,
+      variables: {
+        connections: [connection],
+        mealPlanId: id.toString(),
+      },
+      onCompleted(response, errors) {
+        if (!errors) {
+          res(response);
+          return;
+        }
+        rej(errors);
+      },
+    });
   });
+  
 };

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { MealPlanNode } from "../../state/types";
+import { Avatar, Card, CardActions, CardContent, CardHeader, Collapse, Grid, IconButton, IconButtonProps, ImageList, ImageListItem, Typography, styled } from "@mui/material";
+import { ShoppingCart, DeleteTwoTone, ContentCopy, ExpandMore, Favorite } from "@mui/icons-material";
+import { useNavigate } from "react-router";
+import { getCurrentPerson } from "../../state/state";
+import { deleteMealPlan } from "./DeleteMealPlan";
+import { duplicateMealPlan } from "./DuplicateMealPlan";
+import { RefetchFnDynamic } from "react-relay";
+import { OperationType } from "relay-runtime";
+import { MealPlansQuery$data } from "./__generated__/MealPlansQuery.graphql";
+
+interface MealPlanCardProps {
+    mealplan: MealPlanNode;
+    connection: string;
+    refetch: RefetchFnDynamic<OperationType, MealPlansQuery$data>;
+  }
+
+  interface ExpandMoreProps extends IconButtonProps {
+    expand: boolean;
+  }
+  
+  const ExpandMoreFn = styled((props: ExpandMoreProps) => {
+    const { expand, ...other } = props;
+    return <IconButton {...other} />;
+  })(({ theme, expand }) => ({
+    transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
+    marginLeft: "auto",
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  }));
+  
+const getInitials = (name: string) => {
+    let initials = "";
+    let names: string[] = (name && name.length > 1 && name.split(" ")) || [
+      "No",
+      "Name",
+    ];
+    names.forEach((n) => {
+      initials += n[0];
+    });
+    return initials;
+  };
+
+export const MealPlanCard = (props: MealPlanCardProps) => {
+    const [expanded, setExpanded] = React.useState(false);
+    const navigate = useNavigate();
+    const mealplan = props.mealplan;
+    const connection = props.connection;
+    const handleExpandClick = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setExpanded(!expanded);
+    };
+  
+    return (
+      <Grid item xs="auto">
+        <Card
+          sx={{ maxWidth: 332 }}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(`/mealplans/${mealplan.rowId}`);
+          }}
+          onMouseOver={(e) => {
+            e.currentTarget.style.cursor = "pointer";
+          }}
+        >
+          <CardHeader
+            avatar={
+              <Avatar sx={{ bgcolor: "green", width: "fit" }} aria-label="user">
+                {getInitials(mealplan.person?.fullName || "")}
+              </Avatar>
+            }
+            action={
+              <div>
+                <IconButton
+                  aria-label="shopping list"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log("stopped propagation");
+                    navigate(`/mealplans/${mealplan.rowId}/shopping-list`);
+                  }}
+                >
+                  <ShoppingCart />
+                </IconButton>
+                <IconButton
+                  aria-label="delete"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log("meal plan id: ", typeof mealplan.rowId);
+                    deleteMealPlan(connection, mealplan.rowId).then(() => {
+                      //refetch here for fetching tags after delete
+                      props.refetch({}, {fetchPolicy: "network-only"})
+                    })
+                  }}
+                >
+                  <DeleteTwoTone />
+                </IconButton>
+                {getCurrentPerson().personRole === "app_admin" || getCurrentPerson().personRole === "app_meal_designer" ? (
+                  <IconButton
+                    aria-label="duplicate"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      duplicateMealPlan(connection, mealplan.rowId);
+                    }}
+                  >
+                    <ContentCopy />
+                  </IconButton>
+                ):null}
+              </div>
+            }
+            title={mealplan.nameEn}
+            subheader={mealplan.person?.fullName}
+          />
+          <ImageList sx={{ width: 350, height: 150 }} cols={3} rowHeight={164}>
+            {mealplan.mealPlanEntries.nodes.map((meal) =>
+              meal.meal?.photoUrl !== null ? (
+                <ImageListItem key={meal.meal?.id}>
+                  <img
+                    src={`${meal.meal?.photoUrl}`}
+                    srcSet={`${meal.meal?.photoUrl}`}
+                    alt={meal.meal?.photoUrl || "no image"}
+                    loading="lazy"
+                  />
+                </ImageListItem>
+              ) : (
+                <></>
+              )
+            )}
+          </ImageList>
+          <CardContent>
+            <Typography variant="body2" color="text.secondary">
+              {mealplan.tags?.map((tag) => (
+                <span>{tag} &nbsp;</span>
+              ))}
+            </Typography>
+          </CardContent>
+          <CardActions disableSpacing>
+          <IconButton aria-label="add to favorites">
+              <Favorite />
+            </IconButton>
+  
+            <ExpandMoreFn
+              expand={expanded}
+              onClick={handleExpandClick}
+              aria-expanded={expanded}
+              aria-label="show more"
+            >
+              <ExpandMore />
+            </ExpandMoreFn>
+          </CardActions>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <CardContent>
+              <Typography>
+                {" "}
+                <div>{mealplan.descriptionEn}</div>
+              </Typography>
+            </CardContent>
+          </Collapse>
+        </Card>
+      </Grid>
+    );
+  };

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -1,4 +1,4 @@
-import { DeleteTwoTone, Search, ShoppingCart, ContentCopy } from "@mui/icons-material";
+import { ContentCopy, DeleteTwoTone, ShoppingCart } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
@@ -8,30 +8,29 @@ import {
   CardContent,
   CardHeader,
   Collapse,
+  FormControl,
+  FormControlLabel,
   Grid,
   IconButton,
   IconButtonProps,
   ImageList,
   ImageListItem,
   InputBase,
-  Paper,
-  styled,
-  Typography,
-  Chip,
-  FormControl,
+  Radio,
   RadioGroup,
-  FormControlLabel,
-  Radio
+  Typography,
+  styled
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
+import { getCurrentPerson } from "../../state/state";
 import { MealPlanNode } from "../../state/types";
 import { CreateMealPlan } from "./CreateMealPlan";
 import { deleteMealPlan } from "./DeleteMealPlan";
 import { duplicateMealPlan } from "./DuplicateMealPlan";
-import {getCurrentPerson} from "../../state/state";
+import { MealPlansTags } from "./MealPlansTags";
 import { MealPlansQuery } from "./__generated__/MealPlansQuery.graphql";
 
 interface ExpandMoreProps extends IconButtonProps {
@@ -81,13 +80,15 @@ const mealPlansQuery = graphql`
         }
       }
     }
-    allMealPlanTags(first:10) {
-      edges {
-      node
-      }
-  } 
+    # fragment name from MealPlansTags
+    ...MealPlansTags_tags
+    gqLocalState {
+      selectedMealPlanTags
+    }
   }
 `;
+
+
 
 const getInitials = (name: string) => {
   let initials = "";
@@ -220,31 +221,14 @@ const MealPlanCard = (props: MealPlanCardProps) => {
 
 export const MealPlans = () => {
   const [searched, setSearched] = useState<string>("");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchType, setSearchType] = useState('name');
-  const [fetchKey, setFetchKey] = useState(0);
-
-  const refresh = useCallback(() => {
-    setFetchKey(prevFetchKey => prevFetchKey + 1);
-  }, []);
 
   const data = useLazyLoadQuery<MealPlansQuery>(
     mealPlansQuery,
     {},
-    { fetchPolicy: "network-only", fetchKey }
+    { fetchPolicy: "network-only" }
   );
-
-  const handleTagClick = (tag: string) => {
-    if (selectedTags.includes(tag)) {
-      setSelectedTags(selectedTags.filter(item => item !== tag));
-    } else {
-      setSelectedTags([...selectedTags, tag]);
-    }
-  };
-
-  useEffect(() => {
-    refresh();
-  }, [searchType]);
+  const selectedTags = data.gqLocalState.selectedMealPlanTags || [];
 
   return (
     <div>
@@ -313,25 +297,8 @@ export const MealPlans = () => {
         </span>
         </Grid>
         {searchType === 'tags' &&
-            <Grid container direction="column" margin="0rem 2rem">
-              <div>
-              {data.allMealPlanTags?.edges.map((edge, index) => {
-                const node = edge?.node;
-                if(node !== null) {
-                  return (
-                  <Chip
-                    key={index}
-                    label={node}
-                    clickable
-                    color={selectedTags.includes(node) ? "primary" : "default"}
-                    onClick={() => handleTagClick(node)}
-                    onDelete={selectedTags.includes(node) ? () => handleTagClick(node) : undefined}
-                  />
-                  );
-                }})}
-              </div>
-            </Grid>
-          }
+            <MealPlansTags tags={data}/>
+        }
       {data.mealPlans ? (
         <Grid container spacing={2} margin="1rem" columns={4}>
           {data.mealPlans?.edges.map(({ node }) => {

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -1,57 +1,20 @@
-import { ContentCopy, DeleteTwoTone, ShoppingCart } from "@mui/icons-material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FavoriteIcon from "@mui/icons-material/Favorite";
 import {
-  Avatar,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Collapse,
   FormControl,
   FormControlLabel,
   Grid,
-  IconButton,
-  IconButtonProps,
-  ImageList,
-  ImageListItem,
   InputBase,
   Radio,
-  RadioGroup,
-  Typography,
-  styled
+  RadioGroup
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import React, { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
-import { useNavigate } from "react-router";
-import { getCurrentPerson } from "../../state/state";
-import { MealPlanNode } from "../../state/types";
+import { Suspense, useState } from "react";
+import { useLazyLoadQuery, useRefetchableFragment } from "react-relay";
 import { CreateMealPlan } from "./CreateMealPlan";
-import { deleteMealPlan } from "./DeleteMealPlan";
-import { duplicateMealPlan } from "./DuplicateMealPlan";
-import { MealPlansTags } from "./MealPlansTags";
+import { MealPlanCard } from "./MealPlanCard";
+import { MealPlansTags, MealPlansTagsFragment } from "./MealPlansTags";
 import { MealPlansQuery } from "./__generated__/MealPlansQuery.graphql";
 
-interface ExpandMoreProps extends IconButtonProps {
-  expand: boolean;
-}
 
-const ExpandMore = styled((props: ExpandMoreProps) => {
-  const { expand, ...other } = props;
-  return <IconButton {...other} />;
-})(({ theme, expand }) => ({
-  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
-  marginLeft: "auto",
-  transition: theme.transitions.create("transform", {
-    duration: theme.transitions.duration.shortest,
-  }),
-}));
-
-interface MealPlanCardProps {
-  mealplan: MealPlanNode;
-  connection: string;
-}
 
 const mealPlansQuery = graphql`
   query MealPlansQuery {
@@ -88,137 +51,6 @@ const mealPlansQuery = graphql`
   }
 `;
 
-
-
-const getInitials = (name: string) => {
-  let initials = "";
-  let names: string[] = (name && name.length > 1 && name.split(" ")) || [
-    "No",
-    "Name",
-  ];
-  names.forEach((n) => {
-    initials += n[0];
-  });
-  return initials;
-};
-
-const MealPlanCard = (props: MealPlanCardProps) => {
-  const [expanded, setExpanded] = React.useState(false);
-  const navigate = useNavigate();
-  const mealplan = props.mealplan;
-  const connection = props.connection;
-  const handleExpandClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setExpanded(!expanded);
-  };
-
-  return (
-    <Grid item xs="auto">
-      <Card
-        sx={{ maxWidth: 332 }}
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          navigate(`/mealplans/${mealplan.rowId}`);
-        }}
-        onMouseOver={(e) => {
-          e.currentTarget.style.cursor = "pointer";
-        }}
-      >
-        <CardHeader
-          avatar={
-            <Avatar sx={{ bgcolor: "green", width: "fit" }} aria-label="user">
-              {getInitials(mealplan.person?.fullName || "")}
-            </Avatar>
-          }
-          action={
-            <div>
-              <IconButton
-                aria-label="shopping list"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log("stopped propagation");
-                  navigate(`/mealplans/${mealplan.rowId}/shopping-list`);
-                }}
-              >
-                <ShoppingCart />
-              </IconButton>
-              <IconButton
-                aria-label="delete"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  console.log("meal plan id: ", typeof mealplan.rowId);
-                  deleteMealPlan(connection, mealplan.rowId);
-                }}
-              >
-                <DeleteTwoTone />
-              </IconButton>
-              {getCurrentPerson().personRole === "app_admin" || getCurrentPerson().personRole === "app_meal_designer" ? (
-                <IconButton
-                  aria-label="duplicate"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    duplicateMealPlan(connection, mealplan.rowId);
-                  }}
-                >
-                  <ContentCopy />
-                </IconButton>
-              ):null}
-            </div>
-          }
-          title={mealplan.nameEn}
-          subheader={mealplan.person?.fullName}
-        />
-        <ImageList sx={{ width: 350, height: 150 }} cols={3} rowHeight={164}>
-          {mealplan.mealPlanEntries.nodes.map((meal) =>
-            meal.meal?.photoUrl !== null ? (
-              <ImageListItem key={meal.meal?.id}>
-                <img
-                  src={`${meal.meal?.photoUrl}`}
-                  srcSet={`${meal.meal?.photoUrl}`}
-                  alt={meal.meal?.photoUrl || "no image"}
-                  loading="lazy"
-                />
-              </ImageListItem>
-            ) : (
-              <></>
-            )
-          )}
-        </ImageList>
-        <CardContent>
-          <Typography variant="body2" color="text.secondary">
-            {mealplan.tags?.map((tag) => (
-              <span>{tag} &nbsp;</span>
-            ))}
-          </Typography>
-        </CardContent>
-        <CardActions disableSpacing>
-        <IconButton aria-label="add to favorites">
-            <FavoriteIcon />
-          </IconButton>
-
-          <ExpandMore
-            expand={expanded}
-            onClick={handleExpandClick}
-            aria-expanded={expanded}
-            aria-label="show more"
-          >
-            <ExpandMoreIcon />
-          </ExpandMore>
-        </CardActions>
-        <Collapse in={expanded} timeout="auto" unmountOnExit>
-          <CardContent>
-            <Typography>
-              {" "}
-              <div>{mealplan.descriptionEn}</div>
-            </Typography>
-          </CardContent>
-        </Collapse>
-      </Card>
-    </Grid>
-  );
-};
-
 export const MealPlans = () => {
   const [searched, setSearched] = useState<string>("");
   const [searchType, setSearchType] = useState('name');
@@ -228,6 +60,9 @@ export const MealPlans = () => {
     {},
     { fetchPolicy: "network-only" }
   );
+
+  const [_, refetch] = useRefetchableFragment(MealPlansTagsFragment, data);
+  
   const selectedTags = data.gqLocalState.selectedMealPlanTags || [];
 
   return (
@@ -290,14 +125,16 @@ export const MealPlans = () => {
         </FormControl>
         <span>
         {data.mealPlans ? (
-          <CreateMealPlan connection={data.mealPlans?.__id} />
+          <CreateMealPlan connection={data.mealPlans?.__id} refetch={refetch}  />
         ) : (
           <></>
         )}
         </span>
         </Grid>
         {searchType === 'tags' &&
+          <Suspense fallback={"loading tags..."}>
             <MealPlansTags tags={data}/>
+          </Suspense>
         }
       {data.mealPlans ? (
         <Grid container spacing={2} margin="1rem" columns={4}>
@@ -306,6 +143,7 @@ export const MealPlans = () => {
               return (
                 <MealPlanCard
                   mealplan={node}
+                  refetch={refetch}
                   connection={data.mealPlans!.__id}
                 />
               );

--- a/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
@@ -1,59 +1,66 @@
-import { Chip, Grid } from "@mui/material";
+import { Chip, Grid, Stack } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
 import { useFragment } from "react-relay";
 import { MealPlansTags_tags$key } from "./__generated__/MealPlansTags_tags.graphql";
 import { setSelectedMealPlanTags } from "../../state/state";
 
-const MealPlansTagsFragment = graphql`
-  fragment MealPlansTags_tags on Query{
-    gqLocalState {
-      selectedMealPlanTags
-    }
-    allMealPlanTags(first:100) {
-      edges {
-        node
-      }
-    }
-  }
-`
-
-export const MealPlansTags = ({tags}:{tags: MealPlansTags_tags$key}) => {
-    const mptags = useFragment(MealPlansTagsFragment, tags);
-    // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
-    // When it returns a null, we need to assign an empty array.
-    const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
-    const handleTagClick = (node: string) => {
-        // if tag does not exist, add to the GQLocalState
-        if(!selectedMPTags.includes(node)) {
-            const selectedTags = selectedMPTags.concat([node])
-            setSelectedMealPlanTags(selectedTags);
-            return;
+export const MealPlansTagsFragment = graphql`
+  fragment MealPlansTags_tags on Query
+    @refetchable(queryName: "MealPlansTagsRefetchQuery") {
+        gqLocalState {
+            selectedMealPlanTags
         }
-        // if tag exists, remove from the GQLocalState
-        const index = selectedMPTags.indexOf(node);
-        let selectedTags = [...selectedMPTags];
-        selectedTags.splice(index, 1);
-        setSelectedMealPlanTags(selectedTags);
-    }
+        allMealPlanTags(first:100) {
+            edges {
+                node
+            }
+        }
+  }
+`;
 
-    return (
-        <Grid container direction="column" margin="0rem 2rem">
-              <div>
-              {mptags.allMealPlanTags?.edges.map((edge, index) => {
-                const node = edge?.node;
-                if(node !== null) {
-                  return (
-                  <Chip
-                    key={index}
-                    label={node}
-                    clickable
-                    color={selectedMPTags.includes(node) ? "primary" : "default"}
-                    onClick={() => handleTagClick(node)}
-                    onDelete={selectedMPTags.includes(node) ? () => handleTagClick(node) : undefined}
-                  />
-                  );
-                }})}
-              </div>
-        </Grid>
-    )
-}
+export const MealPlansTags = ({ tags }: { tags: MealPlansTags_tags$key }) => {
+  const mptags = useFragment(MealPlansTagsFragment, tags);
+  // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
+  // When it returns a null, we need to assign an empty array.
+  const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
+  const handleTagClick = (node: string) => {
+    // if tag does not exist, add to the GQLocalState
+    if (!selectedMPTags.includes(node)) {
+      const selectedTags = selectedMPTags.concat([node]);
+      setSelectedMealPlanTags(selectedTags);
+      return;
+    }
+    // if tag exists, remove from the GQLocalState
+    const index = selectedMPTags.indexOf(node);
+    let selectedTags = [...selectedMPTags];
+    selectedTags.splice(index, 1);
+    setSelectedMealPlanTags(selectedTags);
+  };
+
+  return (
+    <Grid container direction="column" margin="0rem 2rem">
+      <Stack direction="row" spacing={1}>
+        {mptags.allMealPlanTags?.edges.map((edge, index) => {
+          const node = edge?.node;
+          if (node !== null) {
+            return (
+            
+              <Chip
+                key={index}
+                label={node}
+                clickable
+                color={selectedMPTags.includes(node) ? "primary" : "default"}
+                onClick={() => handleTagClick(node)}
+                onDelete={
+                  selectedMPTags.includes(node)
+                    ? () => handleTagClick(node)
+                    : undefined
+                }
+              />
+            );
+          }
+        })}
+      </Stack>
+    </Grid>
+  );
+};

--- a/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
@@ -1,0 +1,59 @@
+import { Chip, Grid } from "@mui/material";
+import { graphql } from "babel-plugin-relay/macro";
+import { useFragment } from "react-relay";
+import { MealPlansTags_tags$key } from "./__generated__/MealPlansTags_tags.graphql";
+import { setSelectedMealPlanTags } from "../../state/state";
+
+const MealPlansTagsFragment = graphql`
+  fragment MealPlansTags_tags on Query{
+    gqLocalState {
+      selectedMealPlanTags
+    }
+    allMealPlanTags(first:100) {
+      edges {
+        node
+      }
+    }
+  }
+`
+
+export const MealPlansTags = ({tags}:{tags: MealPlansTags_tags$key}) => {
+    const mptags = useFragment(MealPlansTagsFragment, tags);
+    // If nothing is selected, mptags.gqLocalState.selectedMealPlanTags will return a null
+    // When it returns a null, we need to assign an empty array.
+    const selectedMPTags = mptags.gqLocalState.selectedMealPlanTags || [];
+    const handleTagClick = (node: string) => {
+        // if tag does not exist, add to the GQLocalState
+        if(!selectedMPTags.includes(node)) {
+            const selectedTags = selectedMPTags.concat([node])
+            setSelectedMealPlanTags(selectedTags);
+            return;
+        }
+        // if tag exists, remove from the GQLocalState
+        const index = selectedMPTags.indexOf(node);
+        let selectedTags = [...selectedMPTags];
+        selectedTags.splice(index, 1);
+        setSelectedMealPlanTags(selectedTags);
+    }
+
+    return (
+        <Grid container direction="column" margin="0rem 2rem">
+              <div>
+              {mptags.allMealPlanTags?.edges.map((edge, index) => {
+                const node = edge?.node;
+                if(node !== null) {
+                  return (
+                  <Chip
+                    key={index}
+                    label={node}
+                    clickable
+                    color={selectedMPTags.includes(node) ? "primary" : "default"}
+                    onClick={() => handleTagClick(node)}
+                    onDelete={selectedMPTags.includes(node) ? () => handleTagClick(node) : undefined}
+                  />
+                  );
+                }})}
+              </div>
+        </Grid>
+    )
+}

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5ead987bd34bf3d8205f8e719987dbb8>>
+ * @generated SignedSource<<3849a6d3c82c32401fbea5af0aa1917b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type MealPlansQuery$variables = {};
 export type MealPlansQuery$data = {
   readonly mealPlans: {
@@ -35,6 +36,10 @@ export type MealPlansQuery$data = {
       };
     }>;
   } | null;
+  readonly gqLocalState: {
+    readonly selectedMealPlanTags: ReadonlyArray<string> | null;
+  };
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
 };
 export type MealPlansQuery = {
   variables: MealPlansQuery$variables;
@@ -161,7 +166,30 @@ v11 = {
     }
   ]
 },
-v12 = [
+v12 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GQLocalState",
+      "kind": "LinkedField",
+      "name": "gqLocalState",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "selectedMealPlanTags",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -254,7 +282,13 @@ return {
           (v11/*: any*/)
         ],
         "storageKey": "__connection_mealPlans_connection(orderBy:[\"CREATED_AT_DESC\"])"
-      }
+      },
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealPlansTags_tags"
+      },
+      (v12/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -267,7 +301,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "concreteType": "MealPlansConnection",
         "kind": "LinkedField",
         "name": "mealPlans",
@@ -346,7 +380,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v12/*: any*/),
+        "args": (v13/*: any*/),
         "filters": [
           "orderBy"
         ],
@@ -354,11 +388,47 @@ return {
         "key": "connection_mealPlans",
         "kind": "LinkedHandle",
         "name": "mealPlans"
-      }
+      },
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealPlanTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealPlanTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealPlanTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealPlanTags(first:100)"
+      },
+      (v12/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "1c433e426b71dc78259ad06b4394d55d",
+    "cacheID": "5a880ca0cdd8fd42e200cf9e45a3554b",
     "id": null,
     "metadata": {
       "connection": [
@@ -374,11 +444,11 @@ return {
     },
     "name": "MealPlansQuery",
     "operationKind": "query",
-    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a8120207cca27b22c9e92fea33cdf3ff";
+(node as any).hash = "6db72941db50511d305c9cb41483d7bb";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTagsRefetchQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTagsRefetchQuery.graphql.ts
@@ -1,0 +1,116 @@
+/**
+ * @generated SignedSource<<c634920cfebd8f560eea5e9750914240>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealPlansTagsRefetchQuery$variables = {};
+export type MealPlansTagsRefetchQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
+};
+export type MealPlansTagsRefetchQuery = {
+  variables: MealPlansTagsRefetchQuery$variables;
+  response: MealPlansTagsRefetchQuery$data;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MealPlansTagsRefetchQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealPlansTags_tags"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MealPlansTagsRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealPlanTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealPlanTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealPlanTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealPlanTags(first:100)"
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "GQLocalState",
+            "kind": "LinkedField",
+            "name": "gqLocalState",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "selectedMealPlanTags",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "17379b146ec46e9b2f502cd8bfe3a545",
+    "id": null,
+    "metadata": {},
+    "name": "MealPlansTagsRefetchQuery",
+    "operationKind": "query",
+    "text": "query MealPlansTagsRefetchQuery {\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "3511bb24130d79d02ff559004c9b7492";
+
+export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd1afa085b409d6e60f2ba71919820e7>>
+ * @generated SignedSource<<7a58edcf14ed094536bfa2cc0e0a6578>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -8,7 +8,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { Fragment, ReaderFragment } from 'relay-runtime';
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type MealPlansTags_tags$data = {
   readonly gqLocalState: {
@@ -29,7 +29,13 @@ export type MealPlansTags_tags$key = {
 const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
-  "metadata": null,
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./MealPlansTagsRefetchQuery.graphql')
+    }
+  },
   "name": "MealPlansTags_tags",
   "selections": [
     {
@@ -95,6 +101,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "77d5522adf80567a53a300e40d8e1dcf";
+(node as any).hash = "3511bb24130d79d02ff559004c9b7492";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansTags_tags.graphql.ts
@@ -1,0 +1,100 @@
+/**
+ * @generated SignedSource<<fd1afa085b409d6e60f2ba71919820e7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealPlansTags_tags$data = {
+  readonly gqLocalState: {
+    readonly selectedMealPlanTags: ReadonlyArray<string> | null;
+  };
+  readonly allMealPlanTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null;
+    }>;
+  } | null;
+  readonly " $fragmentType": "MealPlansTags_tags";
+};
+export type MealPlansTags_tags$key = {
+  readonly " $data"?: MealPlansTags_tags$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MealPlansTags_tags">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "MealPlansTags_tags",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AllMealPlanTagsConnection",
+      "kind": "LinkedField",
+      "name": "allMealPlanTags",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AllMealPlanTagEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "node",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "allMealPlanTags(first:100)"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "GQLocalState",
+          "kind": "LinkedField",
+          "name": "gqLocalState",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "selectedMealPlanTags",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "77d5522adf80567a53a300e40d8e1dcf";
+
+export default node;

--- a/mealplanner-ui/src/state/schema.local.graphql
+++ b/mealplanner-ui/src/state/schema.local.graphql
@@ -5,6 +5,7 @@
 type GQLocalState {
     selectedMeal: SelectedMeal
     currentUser: CurrentLoggedInUser
+    selectedMealPlanTags: [String!]
 }
 
 type SelectedMeal {

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -39,6 +39,13 @@ export const initState = () => {
   });
 };
 
+export const setSelectedMealPlanTags = (mpTags: string[]) => {
+  commitLocalUpdate(environment, (store) => {
+    const localState = store.get(STATE_ID);
+    localState?.setValue(mpTags, "selectedMealPlanTags");
+  })
+}
+
 export const setSelectedMeal = (meal: SearchedMeal) => {
   commitLocalUpdate(environment, (store) => {
     const localState = store.get(STATE_ID);


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
This PR creates a graphql fragment for filter by tags for meal plans and adds selected mealplan tags to GQLocalState. 
This fragment key is passed from the MealPlans parent to the MealPlansTags child component to update the selected MealPlan tags.

**Previous behaviour**
Earlier, the state of meal plan tags was not handled. The mealplan tags was part of the MealPlans query itself.

**New behaviour**
Now the mealplan tags is its own React component and a fragment is created. The state for the selectedMealPlanTags is also created and handled in relay GQLState.

**Related issues addressed by this PR**
Fixes #522 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes? -> No, QA will be creating this.
- [ ] Do all of the test cases pass? -> Tested basic scenarios
- [ ] Has the testing been done using the default docker-compose environment? - yes
- [ ] Are documentation changes required? - No
- [ ] Does this change break or alter existing behaviour? - Yes

