### PR TITLE
517 filter meals based on tags

### DIFF
--- a/mealplanner-ui/src/pages/Meals/MealCard.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealCard.tsx
@@ -1,7 +1,6 @@
-import { useTheme } from "@emotion/react";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FavoriteIcon from "@mui/icons-material/Favorite";
-import { Grid, Card, CardHeader, CardMedia, CardContent, Typography, CardActions, IconButton, Collapse, IconButtonProps, styled } from "@mui/material";
+import { useTheme, Grid, Card, CardHeader, CardMedia, CardContent, Typography, CardActions, IconButton, Collapse, IconButtonProps, styled } from "@mui/material";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { MealNode } from "../../state/types";
@@ -34,7 +33,7 @@ export const MealCard = (props: MealProps) => {
     const theme = useTheme();
     const tagStyle = {
       color: "white",
-      backgroundColor: "primary",
+      backgroundColor: `${theme.palette.primary.dark}`,
       padding: "0 0.5em",
       borderRadius: "1em",
       margin: "0.3em 0",

--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -42,7 +42,7 @@ export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
       <Stack direction="row" spacing={1}>
         {mealTags.allMealTags?.edges.map((edge, index) => {
           const node = edge?.node;
-          if (node !== null && node !==undefined) {
+          if (node !== null && node !== undefined) {
             return (
               <Chip
                 key={index}

--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -1,0 +1,65 @@
+import { Chip, Grid, Stack } from "@mui/material";
+import { graphql } from "babel-plugin-relay/macro";
+import { useFragment } from "react-relay";
+import { MealTags_tags$key } from "./__generated__/MealTags_tags.graphql";
+import { setSelectedMealTags } from "../../state/state";
+
+export const MealTagsFragment = graphql`
+  fragment MealTags_tags on Query
+    @refetchable(queryName: "MealTagsRefetchQuery") {
+        gqLocalState {
+            selectedMealTags
+        }
+        allMealTags(first:100) {
+            edges {
+                node
+            }
+        }
+  }
+`;
+
+export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
+  const mealTags = useFragment(MealTagsFragment, tags);
+  // If nothing is selected, mealTags.gqLocalState.selectedMealTags will return a null
+  // When it returns a null, we need to assign an empty array.
+  const selectedMTags = mealTags.gqLocalState.selectedMealTags || [];
+  const handleTagClick = (node: string) => {
+    // if tag does not exist, add to the GQLocalState
+    if (!selectedMTags.includes(node)) {
+      const selectedTags = selectedMTags.concat([node]);
+      setSelectedMealTags(selectedTags);
+      return;
+    }
+    // if tag exists, remove from the GQLocalState
+    const index = selectedMTags.indexOf(node);
+    let selectedTags = [...selectedMTags];
+    selectedTags.splice(index, 1);
+    setSelectedMealTags(selectedTags);
+  };
+
+  return (
+    <Grid container direction="column" margin="0rem 2rem">
+      <Stack direction="row" spacing={1}>
+        {mealTags.allMealTags?.edges.map((edge, index) => {
+          const node = edge?.node;
+          if (node !== null && node !==undefined) {
+            return (
+              <Chip
+                key={index}
+                label={node}
+                clickable
+                color={selectedMTags.includes(node) ? "primary" : "default"}
+                onClick={() => handleTagClick(node)}
+                onDelete={
+                  selectedMTags.includes(node)
+                    ? () => handleTagClick(node)
+                    : undefined
+                }
+              />
+            );
+          }
+        })}
+      </Stack>
+    </Grid>
+   );
+};

--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -1,12 +1,15 @@
-import { Search } from "@mui/icons-material";
 import {
+  FormControl,
+  FormControlLabel,
   Grid,
   InputBase,
-  Paper
+  Radio,
+  RadioGroup
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
-import { useState } from "react";
-import { useLazyLoadQuery } from "react-relay";
+import {Suspense, useState } from "react";
+import { useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { MealTags, MealTagsFragment } from "./MealTags";
 import { MealsQuery } from "./__generated__/MealsQuery.graphql";
 import { MealCard } from "./MealCard";
 
@@ -26,59 +29,101 @@ const mealsQuery = graphql`
         videoUrl
       }
     }
+    # fragment name from MealTags
+    ...MealTags_tags
+    gqLocalState {
+      selectedMealTags
+    }
   }
 `;
 
-
-
 export const Meals = () => {
   const [searchMeal, setSearchMeal] = useState<string>("");
+  const [searchType, setSearchType] = useState('name');
+
   const data = useLazyLoadQuery<MealsQuery>(
     mealsQuery,
     {},
     { fetchPolicy: "store-or-network" }
   );
+
+  const selectedTags = data.gqLocalState.selectedMealTags || [];
+
   return (
+    <div>
     <Grid
       container
       spacing={2}
       columns={2}
-      justifyContent="center"
-      marginTop="1rem"
+      gap="2rem"
+      margin="1rem 2rem"
+      width="95%"
+      justifyContent="space-between"
     >
-      <Paper
-        component="form"
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          width: "75%",
-          justifyContent: "center",
+      <FormControl component="fieldset">
+      <RadioGroup
+        row
+        aria-label="searchType"
+        name="searchType"
+        value={searchType}
+        onChange={(e) => {
+          setSearchType(e.target.value);
         }}
       >
-        <InputBase
-          sx={{ ml: 1, flex: 1 }}
-          placeholder="Search Meal"
-          inputProps={{ "aria-label": "Search Meal" }}
-          onChange={(e) => setSearchMeal(e.target.value.toLowerCase())}
+       <FormControlLabel
+          value="name"
+          control={
+            <Radio 
+              checked={searchType === 'name'}
+            />
+          }
+          label={
+            <InputBase
+              placeholder="Search Meal"
+              inputProps={{ "aria-label": "Search Meal" }}
+              readOnly={searchType !== 'name'}
+              value={searchMeal}
+              onChange={(e) => {
+                if (searchType === 'name') {
+                  setSearchMeal(e.target.value.toLowerCase());
+                }
+              }}
+              style={{ cursor: 'text',
+                      borderBottom: '1px solid black', width: '40vw' }}
+              />
+          }
         />
-        <Search />
-      </Paper>
-      {data.meals ? (
-        <Grid
-          container
-          spacing={2}
-          justifyContent="center"
-          marginTop="1rem"
-          columns={4}
-        >
-          {data.meals?.nodes.map((node) => {
-            if (node.nameEn.toLowerCase().includes(searchMeal))
-              return <MealCard node={node} />;
-          })}
-        </Grid>
+        <FormControlLabel
+          value="favorites"
+          control={<Radio />}
+          label="Favorites"
+          checked={searchType === 'favorites'}
+        />
+        <FormControlLabel
+          value="tags"
+          control={<Radio />}
+          label="Tags"
+          checked={searchType === 'tags'}
+        /> 
+      </RadioGroup>
+    </FormControl>
+    </Grid>
+      {searchType === 'tags' &&
+        <Suspense fallback={"loading tags..."}>
+        <MealTags tags={data}/>
+      </Suspense>
+    }
+   
+    {data.meals ? (
+      <Grid container spacing={2} margin="1rem" columns={4}>
+        {data.meals?.nodes.map((node) => {
+      if ((searchType === 'name' && node.nameEn.toLowerCase().includes(searchMeal)) || (searchType === 'tags' && selectedTags.every(tag => node.tags?.includes(tag)))) {
+        return <MealCard node={node} />
+    }})}
+  </Grid>
       ) : (
         "No meals"
       )}
-    </Grid>
+    </div>
   );
 };

--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -50,7 +50,7 @@ export const Meals = () => {
   const selectedTags = data.gqLocalState.selectedMealTags || [];
 
   return (
-    <div>
+    <>
     <Grid
       container
       spacing={2}
@@ -124,6 +124,6 @@ export const Meals = () => {
       ) : (
         "No meals"
       )}
-    </div>
+    </>
   );
 };

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealTagsRefetchQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealTagsRefetchQuery.graphql.ts
@@ -1,0 +1,116 @@
+/**
+ * @generated SignedSource<<51c63abb7c226ddc0171801ae0d1fa9f>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealTagsRefetchQuery$variables = Record<PropertyKey, never>;
+export type MealTagsRefetchQuery$data = {
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
+};
+export type MealTagsRefetchQuery = {
+  response: MealTagsRefetchQuery$data;
+  variables: MealTagsRefetchQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "MealTagsRefetchQuery",
+    "selections": [
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealTags_tags"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "MealTagsRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealTags(first:100)"
+      },
+      {
+        "kind": "ClientExtension",
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "GQLocalState",
+            "kind": "LinkedField",
+            "name": "gqLocalState",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "selectedMealTags",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ]
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "90fe2e40edfaecc1092afc28bac5a7bf",
+    "id": null,
+    "metadata": {},
+    "name": "MealTagsRefetchQuery",
+    "operationKind": "query",
+    "text": "query MealTagsRefetchQuery {\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "97df7621ff4ba64d426d7d0c0d4659a2";
+
+export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealTags_tags.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealTags_tags.graphql.ts
@@ -1,0 +1,106 @@
+/**
+ * @generated SignedSource<<72218c9242b191257a80348b3e262521>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type MealTags_tags$data = {
+  readonly allMealTags: {
+    readonly edges: ReadonlyArray<{
+      readonly node: string | null | undefined;
+    }>;
+  } | null | undefined;
+  readonly gqLocalState: {
+    readonly selectedMealTags: ReadonlyArray<string> | null | undefined;
+  };
+  readonly " $fragmentType": "MealTags_tags";
+};
+export type MealTags_tags$key = {
+  readonly " $data"?: MealTags_tags$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": {
+    "refetch": {
+      "connection": null,
+      "fragmentPathInResult": [],
+      "operation": require('./MealTagsRefetchQuery.graphql')
+    }
+  },
+  "name": "MealTags_tags",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        }
+      ],
+      "concreteType": "AllMealTagsConnection",
+      "kind": "LinkedField",
+      "name": "allMealTags",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "AllMealTagEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "node",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "allMealTags(first:100)"
+    },
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "GQLocalState",
+          "kind": "LinkedField",
+          "name": "gqLocalState",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "selectedMealTags",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+
+(node as any).hash = "97df7621ff4ba64d426d7d0c0d4659a2";
+
+export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<09041e94dc85ca5b10bee8ed6546d1ab>>
+ * @generated SignedSource<<cfb8ec032e2e32784428e0a0387e651b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,27 +9,32 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type CategoryT = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK" | "%future added value";
-export type MealsQuery$variables = {};
+import { FragmentRefs } from "relay-runtime";
+export type CategoryT = "BREAKFAST" | "DINNER" | "LUNCH" | "SNACK" | "%future added value";
+export type MealsQuery$variables = Record<PropertyKey, never>;
 export type MealsQuery$data = {
+  readonly gqLocalState: {
+    readonly selectedMealTags: ReadonlyArray<string> | null | undefined;
+  };
   readonly meals: {
     readonly nodes: ReadonlyArray<{
-      readonly rowId: any;
-      readonly nameEn: string;
-      readonly nameFr: string | null;
-      readonly descriptionEn: string | null;
-      readonly descriptionFr: string | null;
-      readonly categories: ReadonlyArray<CategoryT | null> | null;
-      readonly tags: ReadonlyArray<string | null> | null;
+      readonly categories: ReadonlyArray<CategoryT | null | undefined> | null | undefined;
       readonly code: string;
-      readonly photoUrl: string | null;
-      readonly videoUrl: string | null;
+      readonly descriptionEn: string | null | undefined;
+      readonly descriptionFr: string | null | undefined;
+      readonly nameEn: string;
+      readonly nameFr: string | null | undefined;
+      readonly photoUrl: string | null | undefined;
+      readonly rowId: any;
+      readonly tags: ReadonlyArray<string | null | undefined> | null | undefined;
+      readonly videoUrl: string | null | undefined;
     }>;
   } | null;
+  readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
 };
 export type MealsQuery = {
-  variables: MealsQuery$variables;
   response: MealsQuery$data;
+  variables: MealsQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -116,6 +121,29 @@ v10 = {
   "kind": "ScalarField",
   "name": "videoUrl",
   "storageKey": null
+},
+v11 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GQLocalState",
+      "kind": "LinkedField",
+      "name": "gqLocalState",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "selectedMealTags",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
 };
 return {
   "fragment": {
@@ -155,7 +183,13 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "MealTags_tags"
+      },
+      (v11/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -204,20 +238,56 @@ return {
           }
         ],
         "storageKey": "meals(first:1000,orderBy:[\"ID_DESC\"])"
-      }
+      },
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 100
+          }
+        ],
+        "concreteType": "AllMealTagsConnection",
+        "kind": "LinkedField",
+        "name": "allMealTags",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AllMealTagEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "node",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "allMealTags(first:100)"
+      },
+      (v11/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "146cfbf3599982b9e1159ae65c60f39a",
+    "cacheID": "b149ff8b3d1086e08138a1a3d52387d5",
     "id": null,
     "metadata": {},
     "name": "MealsQuery",
     "operationKind": "query",
-    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n}\n"
+    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d3ce343b40931b542f7a72303f4e7f26";
+(node as any).hash = "53d8f93b61dc92a420009b86c5baff5a";
 
 export default node;

--- a/mealplanner-ui/src/state/schema.local.graphql
+++ b/mealplanner-ui/src/state/schema.local.graphql
@@ -6,6 +6,7 @@ type GQLocalState {
     selectedMeal: SelectedMeal
     currentUser: CurrentLoggedInUser
     selectedMealPlanTags: [String!]
+    selectedMealTags: [String!]
 }
 
 type SelectedMeal {

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -46,6 +46,13 @@ export const setSelectedMealPlanTags = (mpTags: string[]) => {
   })
 }
 
+export const setSelectedMealTags = (mealTags: string[]) => {
+  commitLocalUpdate(environment, (store) => {
+    const localState = store.get(STATE_ID);
+    localState?.setValue(mealTags, "selectedMealTags");
+  })
+}
+
 export const setSelectedMeal = (meal: SearchedMeal) => {
   commitLocalUpdate(environment, (store) => {
     const localState = store.get(STATE_ID);


### PR DESCRIPTION
![filter](https://github.com/CivicTechFredericton/mealplanner/assets/97687268/5db4febf-460b-4e79-a0c9-2fa25f4d7d6d)

**Describe the technical changes contained in this PR**
This PR creates a graphql fragment for filter by tags for meals and adds selected meal tags to GQLocalState.
This fragment key is passed from the Meals parent to the MealsTags child component to update the selected Meal tags.

Previous behaviour
Earlier, the state of meal plan tags was not handled. The meal tags was part of the Meals query itself.

New behaviour
Now the meal tags is its own React component and a fragment is created. The state for the selectedMealTags is also created and handled in relay GQLState.

**Related issues addressed by this PR**
Fixes #517 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

