### PR TITLE
[#537] add meal preptime

### DIFF
--- a/backend/migrations/011-add-meal-prepTime.sql
+++ b/backend/migrations/011-add-meal-prepTime.sql
@@ -1,0 +1,6 @@
+alter table app.meal 
+    add column if not exists prep_time numeric,
+    add column if not exists cook_time numeric,
+    add column if not exists portions numeric,
+    drop column if exists serves,
+    drop column if exists cooking_duration;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Modified meal table to include prep time, cook time, portions. Removed cook duration and serves.

**Previous behaviour**
Only cook time and serves.

**New behaviour**
As per the Greener Village recipe documentation, added a new column prep time and changed cooking duration to cook time and changed serves to portions.

**Related issues addressed by this PR**
Fixes #537 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes? No
- [ ] Do all of the test cases pass? No
- [ ] Has the testing been done using the default docker-compose environment? Yes
- [ ] Are documentation changes required? Yes
- [ ] Does this change break or alter existing behaviour? Yes

