### PR TITLE
[#476] - add to favourites icon turns red on mouse hover

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MealPlanNode } from "../../state/types";
-import { Avatar, Card, CardActions, CardContent, CardHeader, Collapse, Grid, IconButton, IconButtonProps, ImageList, ImageListItem, Typography, styled } from "@mui/material";
+import { Avatar, Card, CardActions, CardContent, CardHeader, Collapse, Grid, IconButton, IconButtonProps, ImageList, ImageListItem, Typography, styled, useTheme } from "@mui/material";
 import { ShoppingCart, DeleteTwoTone, ContentCopy, ExpandMore, Favorite } from "@mui/icons-material";
 import { useNavigate } from "react-router";
 import { getCurrentPerson } from "../../state/state";
@@ -48,6 +48,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
     const navigate = useNavigate();
     const mealplan = props.mealplan;
     const connection = props.connection;
+    const theme = useTheme();
     const handleExpandClick = (e: React.MouseEvent) => {
       e.stopPropagation();
       setExpanded(!expanded);
@@ -137,7 +138,10 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
             </Typography>
           </CardContent>
           <CardActions disableSpacing>
-          <IconButton aria-label="add to favorites">
+          <IconButton 
+            aria-label="add to favorites"
+            sx={{ "& :hover": { color: theme.palette.secondary.dark } }}
+          >
               <Favorite />
             </IconButton>
   


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added a fature in MealPlanCard.tsx where the favourites icon turn red on mouse hover.

**Previous behaviour**
Favourites icon doesnt change colours on mouse hover. Stays grey

**New behaviour**
Favourites icon color changes to red on mouse hover

**Related issues addressed by this PR**
Fixes #476 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

