### PR TITLE
548 template meal plan

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -5,7 +5,12 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControl,
+  FormControlLabel,
+  FormLabel,
   Grid,
+  Radio,
+  RadioGroup,
   TextField,
   Tooltip,
 } from "@mui/material";
@@ -36,6 +41,7 @@ type userType = {
 
 export const CreateMealPlan = ({ connection, refetch }: { connection: string, refetch: RefetchFnDynamic<OperationType, MealPlansQuery$data> }) => {
   const [open, setOpen] = useState(false);
+  const [planType, setPlanType] = useState('mealPlan');
 
   const users = useLazyLoadQuery<CreateMealPlanAllUsersQuery>(query, {});
 
@@ -102,139 +108,163 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
         Create Meal plan
       </Button>
       <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>Create New Meal Plan</DialogTitle>
-        <DialogContent
-          style={{
-            justifyContent: "space-around",
-            alignContent: "space-around",
-          }}
-        >
-          <Grid container columns={6} spacing={2}>
-            <Grid item xs={6}>
-              <Autocomplete
-                options={allUsers || []}
-                renderInput={(params) => (
-                  <TextField {...params} label="Assign user" id="user" variant="filled" />
-                )}
-                onChange={(e, value) => {
-                  setUserId(value?.rowId);
-                }}
-              ></Autocomplete>
-            </Grid>
-            <Grid item xs={3}>
-              <Tooltip arrow placement="bottom-start" title={titleEn}>
-                <TextField
-                  id="nameEn"
-                  label="Meal Plan Name*"
-                  autoFocus
-                  margin="dense"
-                  variant="standard"
-                  fullWidth
-                  onChange={(e) => {
-                    setNameEn(e.target.value);
-                  }}
-                />
-              </Tooltip>
-            </Grid>
-            <Grid item xs={3}>
-              <Tooltip arrow placement="bottom-start" title={titleFr}>
-                <TextField
-                  id="nameFr"
-                  label="nom du plan de repas"
-                  margin="dense"
-                  variant="standard"
-                  fullWidth
-                  onChange={(e) => {
-                    setNameFr(e.target.value);
-                  }}
-                />
-              </Tooltip>
-            </Grid>
-            <Grid item xs={3}>
-              <Tooltip arrow placement="bottom-start" title={titleDescEng}>
-                <TextField
-                  id="descriptionEn"
-                  label="Description"
-                  multiline
-                  variant="filled"
-                  fullWidth
-                  onChange={(e) => {
-                    setDescriptionEn(e.target.value);
-                  }}
-                />
-              </Tooltip>
-            </Grid>
-            <Grid item xs={3}>
-              <Tooltip arrow placement="bottom-start" title={titleDescFr}>
-                <TextField
-                  id="descriptionFr"
-                  label="la description"
-                  multiline
-                  variant="filled"
-                  fullWidth
-                  onChange={(e) => {
-                    setDescriptionFr(e.target.value);
-                  }}
-                />
-              </Tooltip>
-            </Grid>
-            <Grid item xs={6}>
-              <Autocomplete
-                multiple
-                freeSolo
-                options={[
-                  "vegetarian",
-                  "vegan",
-                  "gluten-free",
-                  "keto",
-                  "paleo",
-                  "diary-free",
-                  "egg-free",
-                  "nuts-free",
-                ]}
-                renderInput={(params) => (
-                  <TextField
-                    color="primary"
-                    {...params}
-                    variant="filled"
-                    label="tags"
-                    placeholder="add tag"
-                  />
-                )}
-                onChange={(e, value) => {
-                  setTags(value);
-                }}
-              />
-            </Grid>
-          </Grid>
-        </DialogContent>
-        <DialogActions style={{ marginRight: "1rem" }}>
-          <Button
-            disabled={disableButton && !isValid}
-            variant="contained"
-            onClick={(e) => {
-              setDisableButton(true);
-              createMealPlan({
-                nameEn: nameEn,
-                nameFr: nameFr,
-                descEn: descriptionEn,
-                descFr: descriptionFr,
-                personId: userId || null,
-                tags: tags,
-                connections: [connection],
-              }).then(() => {
-                console.log("refetching tags");
-                refetch({}, { fetchPolicy: "network-only" });
-                handleClose();
-              });
-            }}
+      <DialogTitle>
+      <Grid container 
+        spacing={2} 
+        columns={2} 
+        gap="2rem"
+        margin="1rem 2rem"
+        width="95%"
+        justifyContent="space-between">
+      <FormControl component="fieldset">
+          <RadioGroup row
+            aria-label="planType"
+            name="planType"
+            value={planType}
+            onChange={(e) => setPlanType(e.target.value)}
           >
-            Create
-          </Button>
-          <Button onClick={handleClose} variant="outlined">
-            Cancel
-          </Button>
-        </DialogActions>
+            <FormControlLabel
+              value="mealPlan"
+              control={<Radio checked={planType === 'mealPlan'}/>}
+              label="Create New Meal Plan"
+            />
+            <FormControlLabel
+              value="template"
+              control={<Radio checked={planType === 'template'}/>}
+              label="Create New Template"
+            />
+          </RadioGroup>
+        </FormControl>
+        </Grid>
+        </DialogTitle>
+         
+            <DialogContent>
+              <Grid container columns={6} spacing={2}>
+              {planType === "mealPlan" && (
+                <Grid item xs={6}>
+                  <Autocomplete
+                    options={allUsers || []}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Assign user"
+                        id="user"
+                        variant="filled"
+                      />
+                    )}
+                    onChange={(e, value) => {
+                      setUserId(value?.rowId);
+                    }}
+                  ></Autocomplete>
+                </Grid>
+                )}
+                <Grid item xs={3}>
+                  <TextField
+                    id="nameEn"
+                    label="Meal Plan Name*"
+                    autoFocus
+                    margin="dense"
+                    variant="standard"
+                    fullWidth
+                    onChange={(e) => {
+                      setNameEn(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={3}>
+                  <TextField
+                    id="nameFr"
+                    label="nom du plan de repas"
+                    margin="dense"
+                    variant="standard"
+                    fullWidth
+                    onChange={(e) => {
+                      setNameFr(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={3}>
+                  <TextField
+                    id="descriptionEn"
+                    label="Description"
+                    multiline
+                    variant="filled"
+                    fullWidth
+                    onChange={(e) => {
+                      setDescriptionEn(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={3}>
+                  <TextField
+                    id="descriptionFr"
+                    label="la description"
+                    multiline
+                    variant="filled"
+                    fullWidth
+                    onChange={(e) => {
+                      setDescriptionFr(e.target.value);
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={6}>
+                  <Autocomplete
+                    multiple
+                    freeSolo
+                    options={[
+                      "vegetarian",
+                      "vegan",
+                      "gluten-free",
+                      "keto",
+                      "paleo",
+                      "diary-free",
+                      "egg-free",
+                      "nuts-free",
+                    ]}
+                    renderInput={(params) => (
+                      <TextField
+                        color="primary"
+                        {...params}
+                        variant="filled"
+                        label="tags"
+                        placeholder="add tag"
+                      />
+                    )}
+                    onChange={(e, value) => {
+                      setTags(value);
+                    }}
+                  />
+                </Grid>
+              </Grid>
+            </DialogContent>
+            <DialogActions style={{ marginRight: "1rem" }}>
+              <Button
+                disabled={disableButton && !isValid}
+                variant="contained"
+                onClick={(e) => {
+                  setDisableButton(true);
+                  createMealPlan({
+                    nameEn: nameEn,
+                    nameFr: nameFr,
+                    descEn: descriptionEn,
+                    descFr: descriptionFr,
+                    personId: userId || null,
+                    tags: tags,
+                    connections: [connection],
+                  }).then(() => {
+                    console.log('refetching tags');
+                    refetch({}, {fetchPolicy: "network-only"});
+                    handleClose();
+                  });
+                }}
+              >
+                Create
+              </Button>
+              <Button onClick={handleClose} variant="outlined">
+                Cancel
+              </Button>
+            </DialogActions>
+
       </Dialog>
     </>
   );

--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -112,13 +112,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
       </Button>
       <Dialog open={open} onClose={handleClose}>
       <DialogTitle>
-      <Grid container 
-        spacing={2} 
-        columns={2} 
-        gap="2rem"
-        margin="1rem 2rem"
-        width="95%"
-        justifyContent="space-between">
+      <Grid container columns={2} >
       <FormControl component="fieldset">
           <RadioGroup row
             aria-label="planType"
@@ -162,31 +156,36 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
                 </Grid>
                 )}
                 <Grid item xs={3}>
+                <Tooltip arrow placement="bottom-start" title={titleEn}>
                   <TextField
                     id="nameEn"
                     label="Meal Plan Name*"
                     autoFocus
                     margin="dense"
-                    variant="standard"
+                    variant="filled"
                     fullWidth
                     onChange={(e) => {
                       setNameEn(e.target.value);
                     }}
                   />
+                  </Tooltip>
                 </Grid>
                 <Grid item xs={3}>
+                <Tooltip arrow placement="bottom-start" title={titleFr}>
                   <TextField
                     id="nameFr"
                     label="nom du plan de repas"
                     margin="dense"
-                    variant="standard"
+                    variant="filled"
                     fullWidth
                     onChange={(e) => {
                       setNameFr(e.target.value);
                     }}
                   />
+                  </Tooltip>
                 </Grid>
                 <Grid item xs={3}>
+                <Tooltip arrow placement="bottom-start" title={titleDescEng}>
                   <TextField
                     id="descriptionEn"
                     label="Description"
@@ -197,8 +196,10 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
                       setDescriptionEn(e.target.value);
                     }}
                   />
+                  </Tooltip>
                 </Grid>
                 <Grid item xs={3}>
+                <Tooltip arrow placement="bottom-start" title={titleDescFr}>
                   <TextField
                     id="descriptionFr"
                     label="la description"
@@ -209,6 +210,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
                       setDescriptionFr(e.target.value);
                     }}
                   />
+                  </Tooltip>
                 </Grid>
                 <Grid item xs={6}>
                   <Autocomplete

--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -57,6 +57,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
     descriptionFr: "",
     tags: [],
     disableButton: true,
+    isTemplate: false
   }
 
   const [userId, setUserId] = useState<userType | null>(initState.userId);
@@ -67,6 +68,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
   const [tags, setTags] = useState<string[]>(initState.tags);
   const [disableButton, setDisableButton] = useState(initState.disableButton);
   const [currentPerson, setCurrentPerson] = useState(getCurrentPerson());
+  const [isTemplate, setIsTemplate] = useState<boolean>(initState.isTemplate);
 
   const isValid = nameEn !== "";
 
@@ -81,6 +83,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
     setDescriptionEn(initState.descriptionEn);
     setDescriptionFr(initState.descriptionFr);
     setTags(initState.tags);
+    setIsTemplate(initState.isTemplate);
     setDisableButton(initState.disableButton);
     setOpen(false);
   };
@@ -251,6 +254,7 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
                     personId: userId || null,
                     tags: tags,
                     connections: [connection],
+                    isTemplate: planType === 'template' ? true : false
                   }).then(() => {
                     console.log('refetching tags');
                     refetch({}, {fetchPolicy: "network-only"});

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -24,6 +24,7 @@ const fragment = graphql`
     nameFr
     descriptionEn
     tags
+    isTemplate
     person {
       fullName
       rowId
@@ -164,7 +165,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
               fontStyle="normal"
               onClick={(e) => setIsEditUser(true)}
             > 
-            {data.person?.fullName ? data.person.fullName : "No User Assigned"}
+            {data.isTemplate ? "template" : (data.person?.fullName ? data.person.fullName : "No User Assigned")}
               
             </Typography> 
           )}

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -110,10 +110,10 @@ export const MealPlans = () => {
               }
             />
             <FormControlLabel
-              value="favorites"
+              value="template"
               control={<Radio />}
-              label="Favorites"
-              checked={searchType === 'favorites'}
+              label="Template"
+              checked={searchType === 'template'}
             />
             <FormControlLabel
               value="tags"

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -28,6 +28,7 @@ const mealPlansQuery = graphql`
           rowId
           nameEn
           descriptionEn
+          isTemplate
           person {
             fullName
           }
@@ -139,7 +140,7 @@ export const MealPlans = () => {
       {data.mealPlans ? (
         <Grid container spacing={2} margin="1rem" columns={4}>
           {data.mealPlans?.edges.map(({ node }) => {
-          if ((searchType === 'name' && node.nameEn.toLowerCase().includes(searched)) || (searchType === 'tags' && selectedTags.every(tag => node.tags?.includes(tag)))) {
+          if ((searchType === 'name' && node.nameEn.toLowerCase().includes(searched)) && !(node.isTemplate)|| (searchType === 'tags' && selectedTags.every(tag => node.tags?.includes(tag)))) {
               return (
                 <MealPlanCard
                   mealplan={node}
@@ -147,7 +148,17 @@ export const MealPlans = () => {
                   connection={data.mealPlans!.__id}
                 />
               );
-          }})}
+          }
+          else if (searchType === 'template' && node.isTemplate) {
+            return (
+              <MealPlanCard
+                mealplan={node}
+                refetch={refetch}
+                connection={data.mealPlans!.__id}
+              />
+            );
+          }
+        })}
         </Grid>
       ) : (
         "No mealplans"

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlanHeader_mealPlan.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlanHeader_mealPlan.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<208f3976f6f752a50c6e64951a270980>>
+ * @generated SignedSource<<7605a53707a7c0e01c12d2557ddc4adb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type MealPlanHeader_mealPlan$data = {
   readonly nameFr: string | null;
   readonly descriptionEn: string | null;
   readonly tags: ReadonlyArray<string | null> | null;
+  readonly isTemplate: boolean | null;
   readonly person: {
     readonly fullName: string;
     readonly rowId: any;
@@ -73,6 +74,13 @@ return {
     {
       "alias": null,
       "args": null,
+      "kind": "ScalarField",
+      "name": "isTemplate",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "Person",
       "kind": "LinkedField",
       "name": "person",
@@ -95,6 +103,6 @@ return {
 };
 })();
 
-(node as any).hash = "905eb7d4c1b3507a2867696429816eff";
+(node as any).hash = "1e369a55405186ecb62d68d8b109828a";
 
 export default node;

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlanQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlanQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<49327ceb9a0ddd13707589bc36a0ac1c>>
+ * @generated SignedSource<<91a8eaa8defe081cd0e8e39403d60b3f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -222,6 +222,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "isTemplate",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Person",
             "kind": "LinkedField",
             "name": "person",
@@ -368,12 +375,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "94353b8779860dd0549eae03f743f7cb",
+    "cacheID": "d9dcd0e1ff80300431877e7f3375e071",
     "id": null,
     "metadata": {},
     "name": "MealPlanQuery",
     "operationKind": "query",
-    "text": "query MealPlanQuery(\n  $id: BigInt!\n) {\n  ...SearchMeal_data\n  mealPlan(rowId: $id) {\n    ...MealPlanHeader_mealPlan\n    ...Calendar_mealPlan\n    id\n  }\n}\n\nfragment Calendar_mealPlan on MealPlan {\n  rowId\n  id\n  mealPlanEntries(orderBy: [CATEGORY_ASC, DAYS_ASC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        category\n        mealId\n        days\n        meal {\n          id\n          nameEn\n          nameFr\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment MealPlanHeader_mealPlan on MealPlan {\n  rowId\n  nameEn\n  nameFr\n  descriptionEn\n  tags\n  person {\n    fullName\n    rowId\n    id\n  }\n}\n\nfragment SearchMeal_data on Query {\n  meals {\n    nodes {\n      id\n      rowId\n      nameEn\n      tags\n    }\n  }\n}\n"
+    "text": "query MealPlanQuery(\n  $id: BigInt!\n) {\n  ...SearchMeal_data\n  mealPlan(rowId: $id) {\n    ...MealPlanHeader_mealPlan\n    ...Calendar_mealPlan\n    id\n  }\n}\n\nfragment Calendar_mealPlan on MealPlan {\n  rowId\n  id\n  mealPlanEntries(orderBy: [CATEGORY_ASC, DAYS_ASC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        category\n        mealId\n        days\n        meal {\n          id\n          nameEn\n          nameFr\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment MealPlanHeader_mealPlan on MealPlan {\n  rowId\n  nameEn\n  nameFr\n  descriptionEn\n  tags\n  isTemplate\n  person {\n    fullName\n    rowId\n    id\n  }\n}\n\nfragment SearchMeal_data on Query {\n  meals {\n    nodes {\n      id\n      rowId\n      nameEn\n      tags\n    }\n  }\n}\n"
   }
 };
 })();

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3849a6d3c82c32401fbea5af0aa1917b>>
+ * @generated SignedSource<<984c30565cc126180a9d2c0a60532215>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,7 @@ export type MealPlansQuery$data = {
         readonly rowId: any;
         readonly nameEn: string;
         readonly descriptionEn: string | null;
+        readonly isTemplate: boolean | null;
         readonly person: {
           readonly fullName: string;
         } | null;
@@ -93,17 +94,24 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "fullName",
+  "name": "isTemplate",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "tags",
+  "name": "fullName",
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "tags",
+  "storageKey": null
+},
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "Meal",
@@ -122,14 +130,14 @@ v8 = {
   ],
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "PageInfo",
@@ -154,7 +162,7 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -166,7 +174,7 @@ v11 = {
     }
   ]
 },
-v12 = {
+v13 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -189,7 +197,7 @@ v12 = {
     }
   ]
 },
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -235,6 +243,7 @@ return {
                   (v3/*: any*/),
                   (v4/*: any*/),
                   (v5/*: any*/),
+                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -243,11 +252,11 @@ return {
                     "name": "person",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/)
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -264,22 +273,22 @@ return {
                         "name": "nodes",
                         "plural": true,
                         "selections": [
-                          (v8/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
-          (v11/*: any*/)
+          (v11/*: any*/),
+          (v12/*: any*/)
         ],
         "storageKey": "__connection_mealPlans_connection(orderBy:[\"CREATED_AT_DESC\"])"
       },
@@ -288,7 +297,7 @@ return {
         "kind": "FragmentSpread",
         "name": "MealPlansTags_tags"
       },
-      (v12/*: any*/)
+      (v13/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -301,7 +310,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v13/*: any*/),
+        "args": (v14/*: any*/),
         "concreteType": "MealPlansConnection",
         "kind": "LinkedField",
         "name": "mealPlans",
@@ -328,6 +337,7 @@ return {
                   (v3/*: any*/),
                   (v4/*: any*/),
                   (v5/*: any*/),
+                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -336,12 +346,12 @@ return {
                     "name": "person",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       (v2/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -358,7 +368,7 @@ return {
                         "name": "nodes",
                         "plural": true,
                         "selections": [
-                          (v8/*: any*/),
+                          (v9/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
@@ -366,21 +376,21 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v10/*: any*/)
                 ],
                 "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
-          (v11/*: any*/)
+          (v11/*: any*/),
+          (v12/*: any*/)
         ],
         "storageKey": "mealPlans(first:1000,orderBy:[\"CREATED_AT_DESC\"])"
       },
       {
         "alias": null,
-        "args": (v13/*: any*/),
+        "args": (v14/*: any*/),
         "filters": [
           "orderBy"
         ],
@@ -424,11 +434,11 @@ return {
         ],
         "storageKey": "allMealPlanTags(first:100)"
       },
-      (v12/*: any*/)
+      (v13/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "5a880ca0cdd8fd42e200cf9e45a3554b",
+    "cacheID": "4e3e01d91e65e556379dcec273f10159",
     "id": null,
     "metadata": {
       "connection": [
@@ -444,11 +454,11 @@ return {
     },
     "name": "MealPlansQuery",
     "operationKind": "query",
-    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+    "text": "query MealPlansQuery {\n  mealPlans(orderBy: [CREATED_AT_DESC], first: 1000) {\n    edges {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        descriptionEn\n        isTemplate\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n        __typename\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  ...MealPlansTags_tags\n}\n\nfragment MealPlansTags_tags on Query {\n  allMealPlanTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6db72941db50511d305c9cb41483d7bb";
+(node as any).hash = "463d2cac84ba2599ca68d7f03aa5d63e";
 
 export default node;

--- a/mealplanner-ui/src/state/__generated__/state_createMealPlanMutation.graphql.ts
+++ b/mealplanner-ui/src/state/__generated__/state_createMealPlanMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<28fc8c27e94da20c5d0459c0054985ef>>
+ * @generated SignedSource<<b54e36efb882c14a5f0ecec6ddac4427>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type state_createMealPlanMutation$variables = {
   personId?: any | null;
   tags?: ReadonlyArray<string | null> | null;
   connections: ReadonlyArray<string>;
+  isTemplate?: boolean | null;
 };
 export type state_createMealPlanMutation$data = {
   readonly createMealPlan: {
@@ -29,6 +30,7 @@ export type state_createMealPlanMutation$data = {
         readonly nameFr: string | null;
         readonly descriptionEn: string | null;
         readonly descriptionFr: string | null;
+        readonly isTemplate: boolean | null;
         readonly person: {
           readonly fullName: string;
         } | null;
@@ -69,24 +71,29 @@ v2 = {
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "nameEn"
+  "name": "isTemplate"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "nameFr"
+  "name": "nameEn"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "personId"
+  "name": "nameFr"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "personId"
+},
+v7 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "tags"
 },
-v7 = [
+v8 = [
   {
     "fields": [
       {
@@ -100,6 +107,11 @@ v7 = [
             "kind": "Variable",
             "name": "descriptionFr",
             "variableName": "descFr"
+          },
+          {
+            "kind": "Variable",
+            "name": "isTemplate",
+            "variableName": "isTemplate"
           },
           {
             "kind": "Variable",
@@ -130,70 +142,77 @@ v7 = [
     "name": "input"
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "rowId",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "nameEn",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "nameFr",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "descriptionEn",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "descriptionFr",
   "storageKey": null
 },
-v15 = {
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isTemplate",
+  "storageKey": null
+},
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "fullName",
   "storageKey": null
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "tags",
   "storageKey": null
 },
-v17 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "Meal",
@@ -201,7 +220,7 @@ v17 = {
   "name": "meal",
   "plural": false,
   "selections": [
-    (v9/*: any*/),
+    (v10/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -221,7 +240,8 @@ return {
       (v3/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
-      (v6/*: any*/)
+      (v6/*: any*/),
+      (v7/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -229,7 +249,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v8/*: any*/),
         "concreteType": "CreateMealPlanPayload",
         "kind": "LinkedField",
         "name": "createMealPlan",
@@ -243,7 +263,7 @@ return {
             "name": "mealPlanEdge",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -252,12 +272,13 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
                   (v10/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
                   (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -266,11 +287,11 @@ return {
                     "name": "person",
                     "plural": false,
                     "selections": [
-                      (v15/*: any*/)
+                      (v17/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v16/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -287,7 +308,7 @@ return {
                         "name": "nodes",
                         "plural": true,
                         "selections": [
-                          (v17/*: any*/)
+                          (v19/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -310,20 +331,21 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v3/*: any*/),
       (v4/*: any*/),
+      (v5/*: any*/),
       (v1/*: any*/),
       (v2/*: any*/),
-      (v5/*: any*/),
       (v6/*: any*/),
-      (v0/*: any*/)
+      (v7/*: any*/),
+      (v0/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Operation",
     "name": "state_createMealPlanMutation",
     "selections": [
       {
         "alias": null,
-        "args": (v7/*: any*/),
+        "args": (v8/*: any*/),
         "concreteType": "CreateMealPlanPayload",
         "kind": "LinkedField",
         "name": "createMealPlan",
@@ -337,7 +359,7 @@ return {
             "name": "mealPlanEdge",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -346,12 +368,13 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
                   (v10/*: any*/),
                   (v11/*: any*/),
                   (v12/*: any*/),
                   (v13/*: any*/),
                   (v14/*: any*/),
+                  (v15/*: any*/),
+                  (v16/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -360,12 +383,12 @@ return {
                     "name": "person",
                     "plural": false,
                     "selections": [
-                      (v15/*: any*/),
-                      (v9/*: any*/)
+                      (v17/*: any*/),
+                      (v10/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v16/*: any*/),
+                  (v18/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -382,8 +405,8 @@ return {
                         "name": "nodes",
                         "plural": true,
                         "selections": [
-                          (v17/*: any*/),
-                          (v9/*: any*/)
+                          (v19/*: any*/),
+                          (v10/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -418,16 +441,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7ae5e6db5ce9f6f8dee8844980b1d252",
+    "cacheID": "58a732e9bb6510e540fc79017f0da889",
     "id": null,
     "metadata": {},
     "name": "state_createMealPlanMutation",
     "operationKind": "mutation",
-    "text": "mutation state_createMealPlanMutation(\n  $nameEn: String!\n  $nameFr: String\n  $descEn: String\n  $descFr: String\n  $personId: BigInt\n  $tags: [String]\n) {\n  createMealPlan(input: {mealPlan: {nameEn: $nameEn, nameFr: $nameFr, descriptionEn: $descEn, descriptionFr: $descFr, personId: $personId, tags: $tags}}) {\n    mealPlanEdge {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        nameFr\n        descriptionEn\n        descriptionFr\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation state_createMealPlanMutation(\n  $nameEn: String!\n  $nameFr: String\n  $descEn: String\n  $descFr: String\n  $personId: BigInt\n  $tags: [String]\n  $isTemplate: Boolean\n) {\n  createMealPlan(input: {mealPlan: {nameEn: $nameEn, nameFr: $nameFr, descriptionEn: $descEn, descriptionFr: $descFr, personId: $personId, tags: $tags, isTemplate: $isTemplate}}) {\n    mealPlanEdge {\n      cursor\n      node {\n        id\n        rowId\n        nameEn\n        nameFr\n        descriptionEn\n        descriptionFr\n        isTemplate\n        person {\n          fullName\n          id\n        }\n        tags\n        mealPlanEntries {\n          nodes {\n            meal {\n              id\n              photoUrl\n            }\n            id\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7f10f9e9f312613c38b992e1bec1739e";
+(node as any).hash = "44c3cb84e6f7651e066d2fbf63a88458";
 
 export default node;

--- a/mealplanner-ui/src/state/__generated__/state_updateMealPlanMutation.graphql.ts
+++ b/mealplanner-ui/src/state/__generated__/state_updateMealPlanMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3f8ac7d180bb0fb706c7a926078830fa>>
+ * @generated SignedSource<<f0b198daba71f4a4a407b05a23242791>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -236,6 +236,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "isTemplate",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "Person",
                 "kind": "LinkedField",
                 "name": "person",
@@ -262,12 +269,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8b963515f602c6c3077642408ac15214",
+    "cacheID": "61d1fac070c90fe1de8c270a759670bc",
     "id": null,
     "metadata": {},
     "name": "state_updateMealPlanMutation",
     "operationKind": "mutation",
-    "text": "mutation state_updateMealPlanMutation(\n  $mealPlanId: BigInt!\n  $mealPlanName: String\n  $descriptionEn: String\n  $personId: BigInt\n  $tags: [String]\n) {\n  updateMealPlan(input: {patch: {nameEn: $mealPlanName, descriptionEn: $descriptionEn, personId: $personId, tags: $tags}, rowId: $mealPlanId}) {\n    mealPlan {\n      id\n      rowId\n      nameEn\n      descriptionEn\n      personId\n      tags\n      ...MealPlanHeader_mealPlan\n    }\n  }\n}\n\nfragment MealPlanHeader_mealPlan on MealPlan {\n  rowId\n  nameEn\n  nameFr\n  descriptionEn\n  tags\n  person {\n    fullName\n    rowId\n    id\n  }\n}\n"
+    "text": "mutation state_updateMealPlanMutation(\n  $mealPlanId: BigInt!\n  $mealPlanName: String\n  $descriptionEn: String\n  $personId: BigInt\n  $tags: [String]\n) {\n  updateMealPlan(input: {patch: {nameEn: $mealPlanName, descriptionEn: $descriptionEn, personId: $personId, tags: $tags}, rowId: $mealPlanId}) {\n    mealPlan {\n      id\n      rowId\n      nameEn\n      descriptionEn\n      personId\n      tags\n      ...MealPlanHeader_mealPlan\n    }\n  }\n}\n\nfragment MealPlanHeader_mealPlan on MealPlan {\n  rowId\n  nameEn\n  nameFr\n  descriptionEn\n  tags\n  isTemplate\n  person {\n    fullName\n    rowId\n    id\n  }\n}\n"
   }
 };
 })();

--- a/mealplanner-ui/src/state/state.ts
+++ b/mealplanner-ui/src/state/state.ts
@@ -355,6 +355,7 @@ const createMealPlanGQL = graphql`
     $personId: BigInt
     $tags: [String]
     $connections: [ID!]!
+    $isTemplate: Boolean
   ) {
     createMealPlan(
       input: {
@@ -365,6 +366,7 @@ const createMealPlanGQL = graphql`
           descriptionFr: $descFr
           personId: $personId
           tags: $tags
+          isTemplate: $isTemplate
         }
       }
     ) {
@@ -377,6 +379,7 @@ const createMealPlanGQL = graphql`
           nameFr
           descriptionEn
           descriptionFr
+          isTemplate
           person {
             fullName
           }


### PR DESCRIPTION
![header](https://github.com/CivicTechFredericton/mealplanner/assets/97687268/e286e736-c881-4cea-ac37-635e5c45e0c0)
![548 template](https://github.com/CivicTechFredericton/mealplanner/assets/97687268/62bfaf7a-867e-4e07-bf9e-248024183d0e)
![v2 template](https://github.com/CivicTechFredericton/mealplanner/assets/97687268/4a3a247f-3058-418d-b6f8-5c840c3655fa)

**Describe the technical changes contained in this PR**
Modified CreateMealPlan and MealPlans files to allow meal designer and admin to create their own templates for Meal plans.

**Previous behaviour**
There was no option to create template for meal plans

**New behaviour**
Meal desginer/ admin can create templates with no user assigned

**Related issues addressed by this PR**
Fixes #548 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

