### PR TITLE
[#529] - adding prep time, cook time and portions to meal (frontend)

### DIFF
--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -92,9 +92,9 @@ function App() {
               path="/meals"
               element={
                 <Suspense fallback={"loading Meals list..."}>
-                  <LoggedIn>
-                    <Meals />
-                  </LoggedIn> 
+                  {/* </LoggedIn> */}
+                  <Meals />
+                  {/* </LoggedIn> */}
                 </Suspense>
               }
             />

--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -93,7 +93,7 @@ function App() {
               element={
                 <Suspense fallback={"loading Meals list..."}>
                   {/* <LoggedIn> */}
-                   <Meals />
+                  <Meals />
                   {/* </LoggedIn> */}
                 </Suspense>
               }

--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -92,9 +92,9 @@ function App() {
               path="/meals"
               element={
                 <Suspense fallback={"loading Meals list..."}>
-                  {/* <LoggedIn> */}
-                  <Meals />
-                  {/* </LoggedIn> */}
+                  <LoggedIn>
+                    <Meals />
+                  </LoggedIn> 
                 </Suspense>
               }
             />

--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -92,8 +92,8 @@ function App() {
               path="/meals"
               element={
                 <Suspense fallback={"loading Meals list..."}>
-                  {/* </LoggedIn> */}
-                  <Meals />
+                  {/* <LoggedIn> */}
+                   <Meals />
                   {/* </LoggedIn> */}
                 </Suspense>
               }

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -18,7 +18,6 @@ const mealQuery = graphql`
   query MealQuery($mealId: BigInt!) {
     meal(rowId: $mealId) {
       rowId
-      code
       nameEn
       nameFr
       tags
@@ -28,14 +27,15 @@ const mealQuery = graphql`
       photoUrl
       videoUrl
       method
-      cookingDuration
       totalCost
       servingCost
       tips
       servingsSize
       servingsSizeUnit
-      serves
       nutritionRating
+      prepTime
+      cookTime
+      portions
       measures {
         nodes {
           id
@@ -226,8 +226,8 @@ export const Meal = () => {
               {meal?.nutritionRating}
             </Typography>
             <Typography variant="caption">
-              Meal Code: {meal?.code} &nbsp; Cooking Duration:{" "}
-              {meal?.cookingDuration} mins &nbsp; Serves: {meal?.serves} &nbsp;
+              Prep Time:{" "} {meal?.prepTime} mins &nbsp; Cook Time:{" "}
+              {meal?.cookTime} mins &nbsp; Portions: {meal?.portions} &nbsp;
               Serving Size: {meal?.servingsSize} {meal?.servingsSizeUnit} &nbsp;
               Serving Cost: {meal?.servingCost}$
             </Typography>

--- a/mealplanner-ui/src/pages/Meals/Meals.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meals.tsx
@@ -24,7 +24,6 @@ const mealsQuery = graphql`
         descriptionFr
         categories
         tags
-        code
         photoUrl
         videoUrl
       }

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a110771a235e2ba05fff5bedb2047221>>
+ * @generated SignedSource<<28eb43fe7d7baa5612c2577544cd1d22>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,6 @@ export type MealQuery$variables = {
 export type MealQuery$data = {
   readonly meal: {
     readonly rowId: any;
-    readonly code: string;
     readonly nameEn: string;
     readonly nameFr: string | null;
     readonly tags: ReadonlyArray<string | null> | null;
@@ -26,14 +25,15 @@ export type MealQuery$data = {
     readonly photoUrl: string | null;
     readonly videoUrl: string | null;
     readonly method: string | null;
-    readonly cookingDuration: any | null;
     readonly totalCost: any | null;
     readonly servingCost: any | null;
     readonly tips: string | null;
     readonly servingsSize: any | null;
     readonly servingsSizeUnit: string | null;
-    readonly serves: any | null;
     readonly nutritionRating: number | null;
+    readonly prepTime: any | null;
+    readonly cookTime: any | null;
+    readonly portions: any | null;
     readonly measures: {
       readonly nodes: ReadonlyArray<{
         readonly id: string;
@@ -87,126 +87,126 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "code",
+  "name": "nameEn",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "nameEn",
+  "name": "nameFr",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "nameFr",
+  "name": "tags",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "tags",
+  "name": "descriptionEn",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "descriptionEn",
+  "name": "descriptionFr",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "descriptionFr",
+  "name": "categories",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "categories",
+  "name": "photoUrl",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "photoUrl",
+  "name": "videoUrl",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "videoUrl",
+  "name": "method",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "method",
+  "name": "totalCost",
   "storageKey": null
 },
 v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cookingDuration",
+  "name": "servingCost",
   "storageKey": null
 },
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "totalCost",
+  "name": "tips",
   "storageKey": null
 },
 v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingCost",
+  "name": "servingsSize",
   "storageKey": null
 },
 v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "tips",
+  "name": "servingsSizeUnit",
   "storageKey": null
 },
 v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingsSize",
+  "name": "nutritionRating",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingsSizeUnit",
+  "name": "prepTime",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "serves",
+  "name": "cookTime",
   "storageKey": null
 },
 v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "nutritionRating",
+  "name": "portions",
   "storageKey": null
 },
 v21 = {
@@ -334,7 +334,7 @@ return {
                     "name": "product",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/)
+                      (v3/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -413,7 +413,7 @@ return {
                     "name": "product",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v3/*: any*/),
                       (v21/*: any*/)
                     ],
                     "storageKey": null
@@ -435,16 +435,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7d2b9fef4db2b12e4a694c1119b01eb1",
+    "cacheID": "9a499dab367a7b8d081a101f15e9577a",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    cookingDuration\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    serves\n    nutritionRating\n    measures {\n      nodes {\n        id\n        product {\n          nameEn\n          id\n        }\n        unit\n        quantity\n      }\n    }\n    nutrition {\n      id\n    }\n    products {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    nutritionRating\n    prepTime\n    cookTime\n    portions\n    measures {\n      nodes {\n        id\n        product {\n          nameEn\n          id\n        }\n        unit\n        quantity\n      }\n    }\n    nutrition {\n      id\n    }\n    products {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2eb11b0b1b5d5a6601296931e78df327";
+(node as any).hash = "c5c72e6e81ae3195d3bedc20712d6569";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cfb8ec032e2e32784428e0a0387e651b>>
+ * @generated SignedSource<<c4d26ca683518dcc4dbacee1a37810fc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,31 +10,30 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type CategoryT = "BREAKFAST" | "DINNER" | "LUNCH" | "SNACK" | "%future added value";
-export type MealsQuery$variables = Record<PropertyKey, never>;
+export type CategoryT = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK" | "%future added value";
+export type MealsQuery$variables = {};
 export type MealsQuery$data = {
-  readonly gqLocalState: {
-    readonly selectedMealTags: ReadonlyArray<string> | null | undefined;
-  };
   readonly meals: {
     readonly nodes: ReadonlyArray<{
-      readonly categories: ReadonlyArray<CategoryT | null | undefined> | null | undefined;
-      readonly code: string;
-      readonly descriptionEn: string | null | undefined;
-      readonly descriptionFr: string | null | undefined;
-      readonly nameEn: string;
-      readonly nameFr: string | null | undefined;
-      readonly photoUrl: string | null | undefined;
       readonly rowId: any;
-      readonly tags: ReadonlyArray<string | null | undefined> | null | undefined;
-      readonly videoUrl: string | null | undefined;
+      readonly nameEn: string;
+      readonly nameFr: string | null;
+      readonly descriptionEn: string | null;
+      readonly descriptionFr: string | null;
+      readonly categories: ReadonlyArray<CategoryT | null> | null;
+      readonly tags: ReadonlyArray<string | null> | null;
+      readonly photoUrl: string | null;
+      readonly videoUrl: string | null;
     }>;
   } | null;
+  readonly gqLocalState: {
+    readonly selectedMealTags: ReadonlyArray<string> | null;
+  };
   readonly " $fragmentSpreads": FragmentRefs<"MealTags_tags">;
 };
 export type MealsQuery = {
-  response: MealsQuery$data;
   variables: MealsQuery$variables;
+  response: MealsQuery$data;
 };
 
 const node: ConcreteRequest = (function(){
@@ -105,24 +104,17 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "code",
+  "name": "photoUrl",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "photoUrl",
-  "storageKey": null
-},
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "videoUrl",
   "storageKey": null
 },
-v11 = {
+v10 = {
   "kind": "ClientExtension",
   "selections": [
     {
@@ -176,8 +168,7 @@ return {
               (v6/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
-              (v9/*: any*/),
-              (v10/*: any*/)
+              (v9/*: any*/)
             ],
             "storageKey": null
           }
@@ -189,7 +180,7 @@ return {
         "kind": "FragmentSpread",
         "name": "MealTags_tags"
       },
-      (v11/*: any*/)
+      (v10/*: any*/)
     ],
     "type": "Query",
     "abstractKey": null
@@ -225,7 +216,6 @@ return {
               (v7/*: any*/),
               (v8/*: any*/),
               (v9/*: any*/),
-              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -274,20 +264,20 @@ return {
         ],
         "storageKey": "allMealTags(first:100)"
       },
-      (v11/*: any*/)
+      (v10/*: any*/)
     ]
   },
   "params": {
-    "cacheID": "b149ff8b3d1086e08138a1a3d52387d5",
+    "cacheID": "231f5758b2be7731d819ff6bcc627c6b",
     "id": null,
     "metadata": {},
     "name": "MealsQuery",
     "operationKind": "query",
-    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      code\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
+    "text": "query MealsQuery {\n  meals(orderBy: [ID_DESC], first: 1000) {\n    nodes {\n      rowId\n      nameEn\n      nameFr\n      descriptionEn\n      descriptionFr\n      categories\n      tags\n      photoUrl\n      videoUrl\n      id\n    }\n  }\n  ...MealTags_tags\n}\n\nfragment MealTags_tags on Query {\n  allMealTags(first: 100) {\n    edges {\n      node\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "53d8f93b61dc92a420009b86c5baff5a";
+(node as any).hash = "3b25ff9b9842828d3b3e0193ff20195d";
 
 export default node;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
I made changes to the mealplanner-ui to reflect the backend meal table changes. Where we have new columns 'prepTime', 'cookTime', and 'portions'. And we also now dont have columns 'code', 'cookingDuration'

**Previous behaviour**
The 'Meals' page wouldnt display because of the breaking chnages to the meal table.

**New behaviour**
The 'Meals' page now reflect the changes to the meal table. Now, once a user/admin/designer selects a meal to look at the details of the meal, they will see 'Prep Time', 'Cook Time', and 'Portions'.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/a8c1d5fc-5112-40e6-ab36-45c3f396f8e1)


**Related issues addressed by this PR**
Fixes #529

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

