### PR TITLE
564 unique meal and ingredient codes

### DIFF
--- a/admin-ui/src/Meals/MealForm.tsx
+++ b/admin-ui/src/Meals/MealForm.tsx
@@ -11,6 +11,7 @@ export const MealForm = () => {
     <SimpleForm>
       <TextInput source="nameEn" fullWidth />
       <TextInput source="nameFr" fullWidth />
+      <NumberInput source="code" fullWidth min={1}/>
       <TextInput
         defaultValue={null}
         fullWidth

--- a/backend/migrations/014-ingredient-and-meal-code.sql
+++ b/backend/migrations/014-ingredient-and-meal-code.sql
@@ -1,6 +1,6 @@
 begin;
-ALTER table app.meal add column if not exists code int;
-ALTER table app.ingredient add column if not exists code int;
+ALTER table app.meal add column if not exists code int unique;
+ALTER table app.ingredient add column if not exists code int unique;
 comment on column app.meal.code is 'Unique code for the meal such 1, 2, 3, etc to later show as M001 - need not be same as the db id';
 comment on column app.ingredient.code is 'Unique code for the ingredient such 1, 2, 3, to later combine as M001-I01';
 commit;

--- a/backend/migrations/014-ingredient-and-meal-code.sql
+++ b/backend/migrations/014-ingredient-and-meal-code.sql
@@ -1,0 +1,6 @@
+begin;
+ALTER table app.meal add column if not exists code int;
+ALTER table app.ingredient add column if not exists code int;
+comment on column app.meal.code is 'Unique code for the meal such 1, 2, 3, etc to later show as M001 - need not be same as the db id';
+comment on column app.ingredient.code is 'Unique code for the ingredient such 1, 2, 3, to later combine as M001-I01';
+commit;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added a meal code and ingredient code as number. This number is as per what Greener village shared the recipe to us and is alphabetic as of now and will be different from the database row id.

**Previous behaviour**
There was no ingredient code and meal code was a text earlier which didn't serve this purpose.

**New behaviour**
Meal and Ingredient has numeric unique codes.

**Related issues addressed by this PR**
Fixes #564 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes? no
- [ ] Do all of the test cases pass? yes
- [ ] Has the testing been done using the default docker-compose environment? yes
- [ ] Are documentation changes required? yes
- [ ] Does this change break or alter existing behaviour? yes

