### PR TITLE
Move away from hand rolled migration to a migration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,47 @@ export COMPOSE_FILE=docker-compose-dev.yml
 docker-compose up --build
 ```
 
+### Migrations
+
+To run the migrations you need to run it under the dev mode (`docker-compose-dev.yml`). 
+
+```
+export COMPOSE_FILE=docker-compose-dev.yml
+docker-compose run migrator up
+```
+
+To make changes to the database, you need to run the create migration script.
+
+```
+export COMPOSE_FILE=docker-compose-dev.yml
+docker-compose run create-migration migration_name
+```
+
+This will create the the two migration files under the `db_migrations` folder.
+
+```
+backend/db_migrations/<sequence>_<migration_name>.up.sql
+backend/db_migrations/<sequence>_<migration_name>.down.sql
+```
+
+The `up` migration will have the code to effect the change you want
+to make and the `down` migration should have the change that you want
+to roll back. We will NEVER run down migrations in production. Down
+migrations exist only to make developer environments and testing easier.
+
+We will be using [Expand - Contract pattern](https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern)
+while designing our migrations. While this might result in multiple
+migrations for a single change, it prioritizes operations over efficency.
+
+> The expand and contract pattern is a process that database 
+> administrators and software developers can use to transition 
+> data from an old data structure to a new data structure without 
+> affecting uptime. It works by applying changes through a series 
+> of discrete steps designed to introduce the new structure in 
+> the background, prepare the data for live usage, and then switch 
+> over to the new structure seamlessly.
+
+
 ### populating sample data
 On the initial build and startup, the database will be completely empty. There won't even be an account created for logging in. To populate the databse with a handful of users and some recipe material run the appropriate version of the following docker-compose commands to seed the database.
 

--- a/backend/db_migrations/000001_common.down.sql
+++ b/backend/db_migrations/000001_common.down.sql
@@ -1,4 +1,6 @@
 begin;
   drop schema if exists app_private cascade;
   drop schema if exists app cascade;
+  drop function nanoid_optimized(int, text, int, int);
+  drop function nanoid(int, text, float);
 commit;

--- a/backend/db_migrations/000001_common.down.sql
+++ b/backend/db_migrations/000001_common.down.sql
@@ -1,0 +1,4 @@
+begin;
+  drop schema if exists app_private cascade;
+  drop schema if exists app cascade;
+commit;

--- a/backend/db_migrations/000001_common.up.sql
+++ b/backend/db_migrations/000001_common.up.sql
@@ -1,0 +1,155 @@
+begin;
+
+  do language plpgsql $$
+    declare
+      role_exists boolean;
+    begin
+      select true into role_exists from pg_roles where rolname='app_graphile';
+
+      if role_exists is null then
+        create role app_graphile;
+	execute format('grant app_graphile to %I',current_user);
+        execute format('grant connect on database %I to app_graphile',current_database());
+      end if;
+
+      select true into role_exists from pg_roles where rolname='app_anonymous';
+      if role_exists is null then
+        create role app_anonymous;
+        grant app_anonymous to app_graphile;
+      end if;
+
+
+      select true into role_exists from pg_roles where rolname='app_user';
+      if role_exists is null then
+        create role app_user;
+        grant app_user to app_graphile;
+      end if;
+
+      select true into role_exists from pg_roles where rolname='app_meal_designer';
+      if role_exists is null then
+        create role app_meal_designer;
+        grant app_meal_designer to app_graphile;
+      end if;
+
+      select true into role_exists from pg_roles where rolname='app_admin';
+      if role_exists is null then
+        create role app_admin;
+        grant app_admin to app_graphile;
+      end if;
+    end;
+  $$;
+
+
+  create extension if not exists pgcrypto;
+  create schema if not exists app;
+  create schema if not exists app_private;
+
+  -- after schema creation and before function creation
+  alter default privileges revoke execute on functions from public;
+
+  create or replace function app.set_updated_at() returns trigger as $$
+  begin
+    new.updated_at := current_timestamp;
+    new.created_at := old.created_at;
+    return new;
+  end;
+  $$ language plpgsql;
+
+  create or replace function app.set_created_at() returns trigger as $$
+  begin
+    new.created_at := current_timestamp;
+    new.updated_at := new.created_at;
+    return new;
+  end;
+  $$ language plpgsql;
+
+  
+  -- nanoid imports from https://github.com/viascom/nanoid-postgresql
+  -- Apache 2.0 license ©️  Viascom
+  CREATE OR REPLACE FUNCTION nanoid(
+      size int DEFAULT 21, -- The number of symbols in the NanoId String. Must be greater than 0.
+      alphabet text DEFAULT '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', -- The symbols used in the NanoId String. Must contain between 1 and 255 symbols.
+      additionalBytesFactor float DEFAULT 1.6 -- The additional bytes factor used for calculating the step size. Must be equal or greater then 1.
+  )
+      RETURNS text -- A randomly generated NanoId String
+      LANGUAGE plpgsql
+      VOLATILE
+      LEAKPROOF
+      PARALLEL SAFE
+  AS
+  $$
+  DECLARE
+      alphabetArray  text[];
+      alphabetLength int := 64;
+      mask           int := 63;
+      step           int := 34;
+  BEGIN
+      IF size IS NULL OR size < 1 THEN
+          RAISE EXCEPTION 'The size must be defined and greater than 0!';
+      END IF;
+
+      IF alphabet IS NULL OR length(alphabet) = 0 OR length(alphabet) > 255 THEN
+          RAISE EXCEPTION 'The alphabet can''t be undefined, zero or bigger than 255 symbols!';
+      END IF;
+
+      IF additionalBytesFactor IS NULL OR additionalBytesFactor < 1 THEN
+          RAISE EXCEPTION 'The additional bytes factor can''t be less than 1!';
+      END IF;
+
+      alphabetArray := regexp_split_to_array(alphabet, '');
+      alphabetLength := array_length(alphabetArray, 1);
+      mask := (2 << cast(floor(log(alphabetLength - 1) / log(2)) as int)) - 1;
+      step := cast(ceil(additionalBytesFactor * mask * size / alphabetLength) AS int);
+
+      IF step > 1024 THEN
+          step := 1024; -- The step size % can''t be bigger then 1024!
+      END IF;
+
+      RETURN nanoid_optimized(size, alphabet, mask, step);
+  END
+  $$;
+
+  -- Generates an optimized random string of a specified size using the given alphabet, mask, and step.
+  -- This optimized version is designed for higher performance and lower memory overhead.
+  -- No checks are performed! Use it only if you really know what you are doing.
+  DROP FUNCTION IF EXISTS nanoid_optimized(int, text, int, int);
+  CREATE OR REPLACE FUNCTION nanoid_optimized(
+      size int, -- The desired length of the generated string.
+      alphabet text, -- The set of characters to choose from for generating the string.
+      mask int, -- The mask used for mapping random bytes to alphabet indices. Should be `(2^n) - 1` where `n` is a power of 2 less than or equal to the alphabet size.
+      step int -- The number of random bytes to generate in each iteration. A larger value may speed up the function but increase memory usage.
+  )
+      RETURNS text -- A randomly generated NanoId String
+      LANGUAGE plpgsql
+      VOLATILE
+      LEAKPROOF
+      PARALLEL SAFE
+  AS
+  $$
+  DECLARE
+      idBuilder      text := '';
+      counter        int  := 0;
+      bytes          bytea;
+      alphabetIndex  int;
+      alphabetArray  text[];
+      alphabetLength int  := 64;
+  BEGIN
+      alphabetArray := regexp_split_to_array(alphabet, '');
+      alphabetLength := array_length(alphabetArray, 1);
+
+      LOOP
+          bytes := gen_random_bytes(step);
+          FOR counter IN 0..step - 1
+              LOOP
+                  alphabetIndex := (get_byte(bytes, counter) & mask) + 1;
+                  IF alphabetIndex <= alphabetLength THEN
+                      idBuilder := idBuilder || alphabetArray[alphabetIndex];
+                      IF length(idBuilder) = size THEN
+                          RETURN idBuilder;
+                      END IF;
+                  END IF;
+              END LOOP;
+      END LOOP;
+  END
+  $$;
+commit;

--- a/backend/db_migrations/000002_auth_system.down.sql
+++ b/backend/db_migrations/000002_auth_system.down.sql
@@ -1,0 +1,9 @@
+begin;
+  drop function if exists app.register_person(text, text, text);
+  drop function if exists app.authenticate(text, text);
+  drop function if exists app.current_person();
+  drop table app_private.account cascade;
+  drop table app.person cascade;
+  drop type app.current_user;
+  drop type app.jwt_token;
+commit;

--- a/backend/db_migrations/000002_auth_system.down.sql
+++ b/backend/db_migrations/000002_auth_system.down.sql
@@ -1,7 +1,10 @@
 begin;
   drop function if exists app.register_person(text, text, text);
   drop function if exists app.authenticate(text, text);
+  drop function if exists app.authorize_admin(bigint);
+  drop function if exists app.authorize_meal_designer(bigint);
   drop function if exists app.current_person();
+  drop function if exists app.current_user_person(app.current_user);
   drop table app_private.account cascade;
   drop table app.person cascade;
   drop type app.current_user;

--- a/backend/db_migrations/000002_auth_system.up.sql
+++ b/backend/db_migrations/000002_auth_system.up.sql
@@ -1,0 +1,192 @@
+begin;
+  create type app.role_type as  enum ('app_user', 'app_meal_designer', 'app_admin');
+
+  create table if not exists app.person (
+    id bigserial primary key,
+    full_name text not null,
+    role app.role_type not null default 'app_user',
+    email text not null unique,
+    slug text not null default nanoid(10),
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+  );
+  comment on table app.person is 'Person represents a user that can log in and work with the application based on their role.';
+  comment on column app.person.full_name is 'Person''s full name';
+  comment on column app.person.id is 'database id (PK) for the Person';
+
+  create unique index idx_person_slug
+      on app.person (slug);
+  commit;
+
+
+  create trigger tg_person_set_updated_at before update
+  on app.person 
+  for each row execute procedure app.set_updated_at();
+  
+  create trigger tg_person_set_created_at before insert
+  on app.person 
+  for each row execute procedure app.set_created_at();
+  
+  create table if not exists app_private.account (
+    person_id bigint primary key references app.person(id) on delete cascade,
+    password_hash text not null,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+  );
+
+  comment on table app_private.account is 'Table to store person private details';
+
+  create trigger tg_account_set_updated_at
+  before update on app_private.account 
+  for each row execute procedure app.set_updated_at();
+
+  create trigger tg_account_set_created_at before insert
+  on app_private.account 
+  for each row execute procedure app.set_created_at();
+
+  create extension if not exists pgcrypto;
+
+ -- create user --
+
+  create type app.jwt_token as (
+    role text,
+    person_id bigint,
+    exp bigint
+  );
+
+
+  create type app.current_user as (id bigint, role text, email text, full_name text, slug text);
+
+
+create or replace function app.register_person(
+    full_name text,
+    email text,
+    password text
+) returns app.person as $$
+    declare p app.person;
+begin
+    insert into app.person (full_name, email)
+    values (full_name, email)
+    returning * into p;
+    insert into app_private.account(person_id, password_hash)
+    values (p.id, crypt(password, gen_salt('bf')));
+    return p;
+end;
+$$ language plpgsql security definer;
+
+--replacing the function to include app.person.role (from person table) in the jwt_token
+create or replace function app.authenticate(user_email text, password text) returns app.jwt_token as $$
+    declare acct app_private.account;
+    person app.person;
+begin
+    select * into person
+        from app.person p
+        where p.email = user_email;
+    select * into acct
+        from app_private.account a
+        where a.person_id = person.id;
+    -- The salt is stored along with the password_hash. The crypt function
+    -- will read the bytes corresponding to the salt from the password_hash column
+    if acct.password_hash = crypt(password, acct.password_hash) THEN return (
+        person.role::text,
+        acct.person_id,
+        extract(epoch from (now() + interval '7 days'))
+    )::app.jwt_token;
+    end if;
+    return null;
+end;
+$$ language plpgsql security definer;
+ comment on function app.authenticate(text,text) is 'Login method for People. Username and password are authenticated against the account table. On success a JWT is created with claims for Person and role.';
+
+create or replace function app.make_first_user_admin() returns trigger as $$
+    declare person_count int;
+begin
+    select count(1) into person_count
+    from app.person;
+    if person_count = 0 then 
+        new.role = 'app_admin';
+    end if;
+    return new;
+end;
+$$ language plpgsql security definer;
+create trigger tg_person_make_admin 
+before insert on app.person 
+for each row execute procedure app.make_first_user_admin();
+
+create or replace function app.authorize_admin(p_id bigint) returns app.person as $$ 
+declare
+p app.person;
+begin
+    update app.person set role='app_admin' where app.person.id = p_id
+    returning * into p;
+    return p;
+end;
+$$ language plpgsql security definer;
+
+
+create or replace function app.authorize_meal_designer(p_id bigint) returns app.person as $$
+declare
+p app.person;
+begin
+    update app.person set role='app_meal_designer' where app.person.id = p_id
+    returning * into p;
+    return p;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app.current_person() returns app.current_user as $$
+    select app.person.id, app.person.role::text, app.person.email, 
+           app.person.full_name, app.person.slug
+    from app.person
+    where id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint
+  $$ language sql stable security definer;
+
+  create or replace function app.current_user_person(cu app.current_user) returns app.person as $$
+    select * from app.person where id=cu.id
+  $$ language sql stable;
+  comment on function app.current_user_person(app.current_user) is 'Person details for current_user.';
+
+  grant usage on schema app to app_anonymous, app_meal_designer, app_user, app_admin;
+
+  grant select, insert on table app.person to app_anonymous, app_user, app_meal_designer, app_admin;
+  grant update, delete on table app.person to app_user, app_meal_designer, app_admin;
+  grant usage, select on sequence app.person_id_seq to app_anonymous, app_user, app_meal_designer, app_admin;
+
+  grant execute on function app.authenticate(text, text) to app_anonymous;
+  grant execute on function app.current_person() to app_anonymous, app_user, app_meal_designer, app_admin;
+  grant execute on function app.current_user_person(app.current_user) to app_user, app_meal_designer, app_admin;
+  grant execute on function app.register_person(text, text, text) to app_admin;
+  -- 2020/02/01 removed app_anonymous from registration
+
+  alter table app.person enable row level security;
+
+  -- admins and meal designers can see all users, others can see only themselves 
+  create policy select_person_user 
+    on app.person 
+    for select 
+    to app_user using (id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+  create policy select_person_meal_designer 
+    on app.person 
+    for select 
+    to app_meal_designer using (true);
+
+  create policy all_person_admin
+    on app.person 
+    for all
+    to app_admin using (true);
+
+  -- users and meal designers can only update themselves
+  create policy update_person_user
+    on app.person 
+    for update
+    to app_user 
+    using (id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+  create policy update_person_meal_designer
+    on app.person 
+    for update
+    to app_meal_designer
+    using (id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+commit;

--- a/backend/db_migrations/000003_nutrition.down.sql
+++ b/backend/db_migrations/000003_nutrition.down.sql
@@ -1,0 +1,3 @@
+begin;
+  drop table app.nutrition cascade;
+commit;

--- a/backend/db_migrations/000003_nutrition.up.sql
+++ b/backend/db_migrations/000003_nutrition.up.sql
@@ -1,0 +1,66 @@
+begin;
+
+create table if not exists app.nutrition (
+    id bigserial primary key,
+    servings_per_container numeric,
+    serving_size numeric,
+    serving_size_unit text,
+    serving_size_text text,
+    calories numeric,
+    total_fat numeric,
+    total_fat_unit text,
+    total_fat_percent numeric,
+    saturated_fat numeric,
+    saturated_fat_unit text,
+    saturated_fat_percent numeric,
+    trans_fat numeric,
+    trans_fat_unit text,
+    trans_fat_percent numeric,
+    cholesterol numeric,
+    cholesterol_unit text,
+    cholesterol_percent numeric,
+    sodium numeric,
+    sodium_unit text,
+    sodium_percent numeric,
+    carbohydrate numeric,
+    carbohydrate_unit text,
+    carbohydrate_percent numeric,
+    dietary_fiber numeric,
+    dietary_fiber_unit text,
+    dietary_fiber_percent numeric,
+    total_sugar numeric,
+    total_sugar_unit text,
+    total_sugar_percent numeric,
+    protein numeric,
+    protein_unit text,
+    protein_percent numeric,
+    vit_a numeric,
+    vit_c numeric,
+    vit_d numeric,
+    vit_b6 numeric,
+    vit_b12 numeric,
+    vit_k numeric,
+    vit_e numeric,
+    calcium numeric,
+    iron numeric,
+    potassium numeric,
+    nutritionable_id bigint not null, -- this id is either app.meal(id) or app.product(id)
+    nutritionable_type text not null, -- the type value is an enum of 'meal' or 'product'
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+comment on table app.nutrition is 'Nutrition details that can be applied to Meals or Products. Not directly related to any other object, the nutritionable_id and nutritional_type are combined to determine the application.';
+
+create trigger tg_nutrition_set_updated_at before update
+on app.nutrition
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_nutrition_set_created_at before insert
+on app.nutrition
+for each row execute procedure app.set_created_at();
+
+grant select on table app.nutrition to app_anonymous, app_user, app_meal_designer, app_admin;
+grant usage on sequence app.nutrition_id_seq to app_meal_designer, app_admin;
+grant insert, update, delete on table app.nutrition to app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000004_product.down.sql
+++ b/backend/db_migrations/000004_product.down.sql
@@ -1,0 +1,3 @@
+begin;
+  drop table app.product cascade;
+commit;

--- a/backend/db_migrations/000004_product.up.sql
+++ b/backend/db_migrations/000004_product.up.sql
@@ -1,0 +1,54 @@
+begin;
+
+create table if not exists app.product (
+    id bigserial primary key,
+    name_en text not null,
+    name_fr text,
+    price numeric not null,
+    quantity numeric not null,
+    unit text not null,
+    is_archived boolean not null default false,
+    upc text,
+    image_url text,
+    source_url text,
+    product_keywords text[], 
+    tags text[],
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+
+create index if not exists 
+    idx_product_product_keywords on app.product using gin(product_keywords);
+
+comment on table app.product is 'Product details for off-the-shelf ingredients. In a Meal this combines with the measure to describe the ingredient and portion. The Product list from Meals in a Meal Plan will be input to a Shopping List.';
+comment on column app.product.name_en is 'Product name in English';
+comment on column app.product.name_fr is 'Product name in French';
+comment on column app.product.price is 'Dollar value in CAD';
+comment on column app.product.quantity is 'The number of units in the item as it is sold. Combines with unit to determine the amount of Product in the item.';
+comment on column app.product.unit is 'The unit of measurement applied to quantity to determine amount of Product sold.';
+comment on column app.product.is_archived is '??';
+comment on column app.product.upc is 'The Universal Product Code or SKU for the retail Product.';
+comment on column app.product.image_url is 'A link to a retailer''s product image.';
+comment on column app.product.source_url is 'A link to a retailer''s listing of the Product. This is meant to be a reference to the source of data for Quantity, Price, UPC, etc.';
+comment on column app.product.tags is 'A list of tags (strings) used to apply attributes to the product listing. May include things like "vegetarian" or "contains peanuts" to facilitate filtering and matching with user''s dietrary needs and so forth. Tag values are determined by the user.';
+
+
+create trigger tg_product_set_updated_at before update
+on app.product 
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_product_set_created_at before insert
+on app.product 
+for each row execute procedure app.set_created_at();
+
+create or replace function app.product_nutrition(p app.product) returns app.nutrition as $$
+  select * from app.nutrition n where n.nutritionable_id=p.id and n.nutritionable_type='product' limit 1;
+$$ language sql stable;
+comment on function app.product_nutrition(app.product) is 'Provides a link from Product to the specific nutritional value for the retail Product item, i.e. the nutritional label on the Product packaging.';
+
+grant execute on function app.product_nutrition(app.product) to app_anonymous, app_user, app_meal_designer, app_admin;
+grant select on table app.product to app_anonymous, app_user, app_meal_designer, app_admin;
+grant usage on sequence app.product_id_seq to app_meal_designer, app_admin;
+grant insert, update, delete on table app.product to app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000004_product.up.sql
+++ b/backend/db_migrations/000004_product.up.sql
@@ -20,7 +20,7 @@ create table if not exists app.product (
 create index if not exists 
     idx_product_product_keywords on app.product using gin(product_keywords);
 
-comment on table app.product is 'Product details for off-the-shelf ingredients. In a Meal this combines with the measure to describe the ingredient and portion. The Product list from Meals in a Meal Plan will be input to a Shopping List.';
+comment on table app.product is 'Product details for off-the-shelf ingredients. In a Meal this combines with the ingredient to describe the ingredient and portion.';
 comment on column app.product.name_en is 'Product name in English';
 comment on column app.product.name_fr is 'Product name in French';
 comment on column app.product.price is 'Dollar value in CAD';

--- a/backend/db_migrations/000005_meal.down.sql
+++ b/backend/db_migrations/000005_meal.down.sql
@@ -1,0 +1,4 @@
+begin;
+  drop table app.meal cascade;
+  drop type app.category_t;
+commit;

--- a/backend/db_migrations/000005_meal.up.sql
+++ b/backend/db_migrations/000005_meal.up.sql
@@ -1,0 +1,85 @@
+begin;
+
+create type app.category_t as enum('Breakfast', 'Lunch', 'Dinner', 'Snack');
+comment on type app.category_t is 'Possible values for Meal category. "Breakfast","Lunch","Dinner","Snack"';
+
+create table if not exists app.meal (
+    id bigserial primary key,
+    code text not null,
+    name_en TEXT not NULL,
+    name_fr TEXT,
+    tags text[],
+    description_en text,
+    description_fr text,
+    categories app.category_t[],
+    photo_url text,
+    video_url text,
+    method text,
+    prep_time numeric,
+    cook_time numeric,
+    total_cost numeric,
+    serving_cost numeric,
+    tips text,
+    servings_size numeric,
+    servings_size_unit text,
+    portions numeric,
+    nutrition_rating integer default 10,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+comment on table app.meal is 'Meal details which comprise a recipe including ingredients and measurements along with preparation instructions.';
+comment on column app.meal.code is 'Unique code for the meal such 1, 2, 3, etc to later show as M001 - need not be same as the db id';
+comment on column app.meal.name_en is 'Short name or title in English';
+comment on column app.meal.name_fr is 'Short name or title in French';
+comment on column app.meal.tags is 'A list of tags (strings) used to apply attributes to the Meal/recipe. May include things like "vegetarian" or "contains peanuts" to facilitate filtering and matching with user''s dietrary needs and so forth. Tag values are determined by the user.';
+comment on column app.meal.description_en is 'Longer form description of the recipe to complement the name, in English';
+comment on column app.meal.description_fr is 'Longer form description of the recipe to complement the name, in French';
+comment on column app.meal.categories is 'Categories for which this Meal is appropriate. This is used to restrict Categories to which a Meal may be assigned within a Meal Plan. These iclude "Breakfast", "Lunch", "Dinner", "Snack"';
+comment on column app.meal.photo_url is '??';
+comment on column app.meal.video_url is '??';
+comment on column app.meal.method is 'The instructions for preparing the recipe, usually in point form. Plain text formatting determined by the user.';
+comment on column app.meal.prep_time is 'The typical time to prep for the recipe, in minutes.';
+comment on column app.meal.cook_time is 'The typical time to complete the recipe, in minutes.';
+comment on column app.meal.total_cost is 'An estimate of the cost of ingredients.';
+comment on column app.meal.serving_cost is 'An estimate of the cost per serving.';
+comment on column app.meal.tips is 'Some tips and tricks that could help make recipe preparation successful.';
+comment on column app.meal.servings_size is 'The numerical size of each serving, combines with servingSizeUnit';
+comment on column app.meal.servings_size_unit is 'The unit of measure to complement servingSize';
+comment on column app.meal.portions is 'The number of people this recipe is meant to serve.';
+comment on column app.meal.nutrition_rating is 'An overall nutritional quality rating from 1 - 10';
+
+create trigger tg_meal_set_updated_at before update
+on app.meal 
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_meal_set_created_at before insert
+on app.meal 
+for each row execute procedure app.set_created_at();
+
+create or replace function app.meal_nutrition(m app.meal) returns app.nutrition as $$
+  select * from app.nutrition n where n.nutritionable_id=m.id and n.nutritionable_type='meal' limit 1;
+$$ language sql stable;
+comment on function app.meal_nutrition(app.meal) is 'Provides a link to the detailed nutritional break down for the recipe, similar to the nutrition label on a Product, if available.';
+
+create or replace function app.all_meal_tags() returns SETOF text as $$
+  select distinct unnest(tags) as tag from app.meal;
+$$ language sql stable;
+
+comment on function app.all_meal_tags() IS 'Unique tags from all meals';
+
+grant execute on function app.all_meal_tags() to app_anonymous, app_user, app_meal_designer, app_admin;
+end;
+
+grant select, insert, update, delete on table app.meal 
+to app_meal_designer, app_admin;
+
+grant select on table app.meal 
+to app_anonymous, app_user, app_meal_designer, app_admin;
+
+grant usage on sequence app.meal_id_seq 
+to app_meal_designer, app_admin;
+
+grant execute on function app.meal_nutrition(app.meal) 
+to app_anonymous, app_user, app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000005_meal.up.sql
+++ b/backend/db_migrations/000005_meal.up.sql
@@ -5,7 +5,7 @@ comment on type app.category_t is 'Possible values for Meal category. "Breakfast
 
 create table if not exists app.meal (
     id bigserial primary key,
-    code text not null,
+    code numeric,
     name_en TEXT not NULL,
     name_fr TEXT,
     tags text[],

--- a/backend/db_migrations/000006_favorite_meals.down.sql
+++ b/backend/db_migrations/000006_favorite_meals.down.sql
@@ -1,0 +1,5 @@
+begin;
+  drop function if exists app.add_favorite_meals(bigint);
+  drop function if exists app.remove_favorite_meals(bigint);
+  drop table app.favorite_meals cascade;
+commit;

--- a/backend/db_migrations/000006_favorite_meals.up.sql
+++ b/backend/db_migrations/000006_favorite_meals.up.sql
@@ -1,0 +1,59 @@
+begin;
+
+create table if not exists app.favorite_meals (
+    id bigserial primary key,
+    meal_id bigint not null references app.meal(id),
+    person_id bigint references app.person(id),
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null,
+    unique (meal_id, person_id)
+);
+
+-- Create triggers to set created_at and updated_at timestamps
+create or replace trigger tg_favorite_meals_set_updated_at before update
+on app.favorite_meals 
+for each row execute procedure app.set_updated_at();
+
+create or replace trigger tg_favorite_meals_set_created_at before insert
+on app.favorite_meals 
+for each row execute procedure app.set_created_at();
+
+-- Create row level security to enable only to view current user favorite meals
+alter table app.favorite_meals enable row level security;
+--An admin will be able to view/create/update favorite meals for any user
+create policy admin_favorite_meals on app.favorite_meals for all to app_admin using(true);
+--A meal designer will be able to view/create/update favorite meals for any user
+create policy meal_designer_favorite_meals on app.favorite_meals for all to app_meal_designer using(true);
+--A user will only be able to view/create/update only if he/she/they are the current logged in user
+create policy user_favorite_meals on app.favorite_meals for all to app_user
+using (person_id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+
+-- Function to add a meal plan to favorites
+create or replace function app.add_favorite_meal(meal_id_param bigint) returns void as $$
+begin
+    -- fetch the person_id from the current session
+    insert into app.favorite_meals (meal_id, person_id)
+    select meal_id_param, nullif(current_setting('jwt.claims.person_id', true), '')::bigint;
+end;
+$$ language plpgsql;
+
+
+-- Function to delete a meal plan from favorites
+create or replace function app.remove_favorite_meal(meal_id_param bigint) returns void as $$
+declare
+    person_id_param bigint;
+begin
+    -- fetch the person_id from the current session
+    person_id_param := nullif(current_setting('jwt.claims.person_id', true), '')::bigint;
+
+    -- delete from favorite_meals table based on meal_id and person_id
+    delete from app.favorite_meals
+    where meal_id = meal_id_param and person_id = person_id_param;
+end;
+$$ language plpgsql;
+
+-- Grant execute permission to appropriate roles
+grant select, insert, delete, update on app.favorite_meals to app_user, app_meal_designer, app_admin;
+grant usage on sequence app.favorite_meals_id_seq to app_user, app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000007_ingredient.down.sql
+++ b/backend/db_migrations/000007_ingredient.down.sql
@@ -1,0 +1,4 @@
+begin;
+  drop function app.product_meals(app.product);
+  drop table app.ingredient cascade;
+commit;

--- a/backend/db_migrations/000007_ingredient.up.sql
+++ b/backend/db_migrations/000007_ingredient.up.sql
@@ -1,0 +1,49 @@
+begin;
+
+create table if not exists app.ingredient (
+    id bigserial primary key,
+    name text not null,
+    code int unique,
+    quantity numeric not null,
+    unit text not null,
+    product_keyword text not null,
+    substitute_ingredient_id bigint references app.ingredient(id),
+    substitute_reason text[],
+    meal_id bigint references app.meal(id) not null,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+
+comment on table app.ingredient is 'Ingredients in the recipe referred with meal_id. Specific to the recipe, not to be confused with the Product quantity and unit.';
+comment on column app.ingredient.unit is 'The measurement type to be used by the preparer, i.e. tsp, tbsp, cup, mL, etc.';
+comment on column app.ingredient.code is 'Unique code for the ingredient such 1, 2, 3, to later combine as M001-I01';
+comment on column app.ingredient.quantity is 'The numerical part of the measurement to be used by the preparer. Combines with unit to describe the measurement such as 1 tbsp, etc.';
+comment on column app.ingredient.product_keyword is 'Reference to the Product item as it would be purchased. Product has tags which are the keywords';
+comment on column app.ingredient.meal_id is 'Reference back to the Meal for which this is an ingredient.';
+comment on column app.ingredient.substitute_ingredient_id is 'If the current record is a substitute to another ingredient, then this represents the other ingredient id';
+comment on column app.ingredient.substitute_reason is 'Reason can be specified such as vegan, gluten-free for which this substitute exists';
+
+
+create trigger tg_ingredient_set_updated_at before update
+on app.ingredient 
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_ingredient_set_created_at before insert
+on app.ingredient
+for each row execute procedure app.set_created_at();
+
+create index idx_ingredient_product_keyword on app.ingredient(product_keyword);
+create index idx_ingredient_meal_id on app.ingredient(meal_id);
+
+create or replace function app.product_meals(p app.product) returns setof app.meal as $$
+     select m.* from app.meal m join app.ingredient ing on m.id = ing.meal_id
+     where ing.product_keyword = any(p.product_keywords);
+$$ language sql stable;
+comment on function app.product_meals(app.product) is 'Provides a link between Product and the Meals in which it is included as an ingredient.';
+
+grant select, insert, update, delete on app.ingredient to app_meal_designer, app_admin;
+grant select on app.ingredient to app_anonymous, app_user;
+grant usage on sequence app.ingredient_id_seq to app_meal_designer, app_admin;
+grant execute on function app.product_meals(app.product) to app_anonymous, app_user, app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000008_match.down.sql
+++ b/backend/db_migrations/000008_match.down.sql
@@ -1,0 +1,8 @@
+begin;
+  drop function app.update_matches(bigint, bigint[]);
+  drop function app.ingredient_matched_products(app.ingredient);
+  drop function app.product_matched_ingredients(app.product);
+  drop function app.product_keyword_ingredients(app.product);
+  drop function app.ingredient_keyword_products(app.ingredient);
+  drop table app.match cascade;
+commit;

--- a/backend/db_migrations/000008_match.up.sql
+++ b/backend/db_migrations/000008_match.up.sql
@@ -1,0 +1,68 @@
+begin;
+create table if not exists app.match (
+    id bigserial primary key,
+    product_id bigint references app.product(id) not null,
+    ingredient_id bigint references app.ingredient(id) not null,
+    relevance int not null,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+
+comment on table app.match is 'Connecting product with a particular ingredient and the relevance';
+comment on column app.match.ingredient_id is 'The ingredient id from the ingredient table';
+comment on column app.match.product_id is 'The product id from the product table';
+comment on column app.match.relevance is 'How relevant is a product to the ingredient - 1 being best, 2 denotes good, not exists if not a match';
+ 
+-- only if you mention STABLE it will be treated as Query, otherwise will be assumed as mutation
+-- SETOF returns a connection which has pageInfo, edges -> cursor, node
+create or replace function app.ingredient_matched_products(i app.ingredient) returns SETOF app.product as $$
+    SELECT p.* 
+    FROM app.product p JOIN app.match mch ON p.id = mch.product_id 
+    WHERE mch.ingredient_id = i.id order by mch.relevance;
+$$ language SQL STABLE;
+comment on function app.ingredient_matched_products(app.ingredient) is 'Given a ingredient, returns a set of products that match';
+
+create or replace function app.product_matched_ingredients(p app.product) returns SETOF app.ingredient as $$
+    SELECT i.*
+    FROM app.ingredient i JOIN app.match mch ON i.id = mch.ingredient_id
+    WHERE mch.product_id = p.id order by mch.relevance;
+$$ language SQL STABLE;
+comment on function app.product_matched_ingredients(app.product) is 'Given a product, returns a set of ingredients that match';
+
+create or replace function app.product_keyword_ingredients(p app.product) returns SETOF app.ingredient as $$
+    SELECT i.*
+    FROM app.ingredient i where i.product_keyword = ANY(p.product_keywords);
+$$ language SQL STABLE;
+comment on function app.product_keyword_ingredients(app.product) is 'Given a product keyword, returns a set of ingredients that have the product keyword';
+
+create or replace function app.ingredient_keyword_products(i app.ingredient) returns SETOF app.product as $$
+    SELECT p.*
+    FROM app.product p where i.product_keyword = ANY(p.product_keywords); 
+$$ language SQL STABLE;
+comment on function app.ingredient_keyword_products(app.ingredient) is 'Given a product keyword from ingredient, returns a set of products that have the product keyword';
+
+create or replace function app.update_matches(ing_id bigint, product_ids bigint[]) returns SETOF app.match as $$
+    declare
+    relevances int[];
+    len int;
+    begin
+        len := array_length(product_ids, 1);
+        select array_agg(s) from generate_series(1, len) s into relevances;
+        delete from app.match where ingredient_id = ing_id;
+        insert into app.match(product_id, ingredient_id, relevance) 
+        select unnest(product_ids), ing_id, unnest(relevances); 
+        return query select * from app.match where ingredient_id = ing_id;
+    end;
+$$ language plpgsql;
+comment on function app.update_matches(bigint, bigint[]) is 'Given an ingredient id and product ids, updates the matches and returns the updated matches';
+
+grant select on table app.match to app_anonymous, app_user, app_admin, app_meal_designer;
+grant insert, update, delete on table app.match to app_meal_designer, app_admin;
+grant usage on sequence app.match_id_seq to app_meal_designer, app_admin;
+grant execute on function app.ingredient_matched_products(app.ingredient) to app_anonymous, app_user, app_meal_designer, app_admin;
+grant execute on function app.product_matched_ingredients(app.product) to app_anonymous, app_user, app_meal_designer, app_admin;
+grant execute on function app.product_keyword_ingredients(p app.product) to app_anonymous, app_user, app_meal_designer, app_admin;
+grant execute on function app.ingredient_keyword_products(i app.ingredient) to app_anonymous, app_user, app_meal_designer, app_admin;
+grant execute on function app.update_matches(ingredient_id bigint, product_ids bigint[]) to app_meal_designer, app_admin;
+
+commit;

--- a/backend/db_migrations/000009_meal_plan.down.sql
+++ b/backend/db_migrations/000009_meal_plan.down.sql
@@ -1,0 +1,4 @@
+begin;
+  drop function app.all_meal_plan_tags();
+  drop table app.meal_plan cascade;
+commit;

--- a/backend/db_migrations/000009_meal_plan.up.sql
+++ b/backend/db_migrations/000009_meal_plan.up.sql
@@ -1,0 +1,75 @@
+begin;
+create table if not exists app.meal_plan (
+    id bigserial primary key,
+    name_en text not null,
+    name_fr text,
+    description_en text,
+    description_fr text,
+    person_id bigint REFERENCES app.person(id),
+    tags text[],
+    is_template boolean default false,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+comment on table app.meal_plan is 'Collection of Meals, organized together in a Plan, typically a weekly plan.';
+comment on column app.meal_plan.name_en is 'A short name for the Plan in English';
+comment on column app.meal_plan.name_fr is 'A short name for the Plan in French';
+comment on column app.meal_plan.description_en is 'A full description of the Meal Plan in English';
+comment on column app.meal_plan.description_fr is 'A full description of the Meal Plan in French';
+comment on column app.meal_plan.person_id is 'Reference to the Person who is the assignee of the Plan';
+comment on column app.meal_plan.is_template is 'This is for mealplans that are maintained as templates';
+comment on column app.meal_plan.tags is 'A list of tags (strings) used to apply attributes to the Meal Plan. May include things like "week one" or "for 5" to facilitate filtering help the user organize plans';
+
+create trigger tg_meal_plan_set_updated_at before update
+on app.meal_plan 
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_meal_plan_set_created_at before insert
+on app.meal_plan 
+for each row execute procedure app.set_created_at();
+
+-- ensure that regular, unprivileged user's new plans are automatically assigned to them
+create or replace function app.set_meal_plan_new_person_id() returns trigger as $$
+  begin
+    if current_user = 'app_user' then
+      new.person_id := nullif(current_setting('jwt.claims.person_id', true), '')::bigint;
+    end if;
+    return new;
+  end;
+  $$ language plpgsql;
+
+
+create trigger tg_meal_plan_set_app_user_person_id before insert
+  on app.meal_plan
+  for each row execute procedure app.set_meal_plan_new_person_id();
+
+create or replace function app.all_meal_plan_tags() returns SETOF text as $$
+  select distinct unnest(tags) as tag from app.meal_plan;
+$$ language sql stable;
+
+comment on function app.all_meal_plan_tags() IS 'Unique tags from all meal plans';
+
+create index idx_meal_plan_person_id on app.meal_plan(person_id);
+
+grant select, insert, delete, update on app.meal_plan to app_user, app_meal_designer, app_admin;
+grant usage on sequence app.meal_plan_id_seq to app_user, app_meal_designer, app_admin;
+grant execute on function app.all_meal_plan_tags() to app_anonymous, app_user, app_meal_designer, app_admin;
+
+alter table app.meal_plan enable row level security;
+
+create policy all_meal_plan_admin
+  on app.meal_plan
+  for all
+  to app_admin using(true);
+
+create policy all_meal_plan_meal_designer
+  on app.meal_plan
+  for all
+  to app_meal_designer using(true);
+
+create policy all_meal_plan_user
+  on app.meal_plan
+  for all
+  to app_user using(person_id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint);
+  
+commit;

--- a/backend/db_migrations/000010_meal_plan_entry.down.sql
+++ b/backend/db_migrations/000010_meal_plan_entry.down.sql
@@ -1,0 +1,4 @@
+begin;
+  drop function app.duplicate_meal_plan(bigint, bigint);
+  drop table app.meal_plan_entry cascade;
+commit;

--- a/backend/db_migrations/000010_meal_plan_entry.up.sql
+++ b/backend/db_migrations/000010_meal_plan_entry.up.sql
@@ -1,0 +1,77 @@
+begin;
+
+create table if not exists app.meal_plan_entry (
+    id bigserial primary key,
+    category app.category_t not null,
+    days int not null,
+    meal_plan_id bigint REFERENCES app.meal_plan(id) ON DELETE CASCADE NOT NULL ,
+    meal_id bigint REFERENCES app.meal(id) NOT NULL,
+    created_at timestamp default now() not null,
+    updated_at timestamp default now() not null
+);
+comment on table app.meal_plan_entry is 'Entries are Meals assigned to days of the week and specific meal times (Breakfast, Lunch, etc) within a specific Plan.';
+comment on column app.meal_plan_entry.category is 'Category or mealtime for the assigned Meal. Can be one of "Breakfast", "Lunch", "Dinner" or "Snack" ';
+comment on column app.meal_plan_entry.days is 'MONDAY: 0, TUESDAY: 1.., SUNDAY: 6';
+comment on column app.meal_plan_entry.meal_plan_id is 'Reference to the Plan in which item belongs.';
+comment on column app.meal_plan_entry.meal_id is 'The Meal that is being assigned to the plan.';
+
+create trigger tg_meal_plan_entry_set_updated_at before update
+on app.meal_plan_entry
+for each row execute procedure app.set_updated_at();
+
+create trigger tg_meal_plan_entry_set_created_at before insert
+on app.meal_plan_entry
+for each row execute procedure app.set_created_at();
+
+create index idx_meal_plan_entry_meal_plan_id on app.meal_plan_entry(meal_plan_id);
+create index idx_meal_plan_entry_meal_id on app.meal_plan_entry(meal_id);
+create index idx_meal_plan_entry_category on app.meal_plan_entry(category);
+create index idx_meal_plan_entry_days on app.meal_plan_entry(days);
+
+create or replace function app.duplicate_meal_plan(mealplan_id bigint, p_id bigint) returns app.meal_plan as $$
+declare
+  m app.meal_plan;
+  entry_ids bigint[];
+begin
+  --create a duplicate meal plan with a different meal plan id and person id p_id but the same contents
+  insert into app.meal_plan (name_en, name_fr, person_id, description_en, description_fr, tags)
+   select name_en, name_fr, p_id as person_id, description_en, description_fr, tags from app.meal_plan where id=mealplan_id
+  returning * into m;
+  -- m = UPDATE app.meal_plan SET person_id=p_id WHERE id = m.id RETURNING *;
+
+  --create duplicate of all meal plan entries associated with the meal_plan_id
+
+  insert into app.meal_plan_entry (category, days, meal_plan_id, meal_id)
+  select category, days, m.id as meal_plan_id, meal_id from app.meal_plan_entry 
+  where meal_plan_id = mealplan_id;
+
+  return m;
+end;
+$$ language plpgsql;
+comment on function app.duplicate_meal_plan(bigint, bigint) is 'Duplicate meal plan by meal designer or admin';
+
+
+
+grant select, insert, delete, update on app.meal_plan_entry to app_user, app_meal_designer, app_admin;
+grant select on app.meal_plan_entry to app_anonymous;
+grant usage on sequence app.meal_plan_entry_id_seq to app_user, app_meal_designer, app_admin;
+grant execute on function app.duplicate_meal_plan(bigint, bigint) to app_admin, app_meal_designer; 
+
+alter table app.meal_plan_entry enable row level security;
+
+create policy all_meal_plan_entry_admin
+  on app.meal_plan_entry
+  for all
+  to app_admin using(true);
+
+create policy all_meal_plan_entry_meal_designer
+  on app.meal_plan_entry
+  for all
+  to app_meal_designer using(true);
+
+create policy all_meal_plan_entry_user
+  on app.meal_plan_entry
+  for all
+  to app_user using(meal_plan_id in (select id from app.meal_plan where person_id = nullif(current_setting('jwt.claims.person_id', true), '')::bigint)); -- NOTE: depends on meal_plan row level policy
+
+COMMIT;

--- a/backend/migrations/016-match.sql
+++ b/backend/migrations/016-match.sql
@@ -54,7 +54,7 @@ create or replace function app.update_matches(ing_id bigint, product_ids bigint[
         return query select * from app.match where ingredient_id = ing_id;
     end;
 $$ language plpgsql;
-comment on function app.update_matches(ingredient id, product id[]) is 'Given an ingredient id and product ids, updates the matches and returns the updated matches';
+comment on function app.update_matches(bigint, bigint[]) is 'Given an ingredient id and product ids, updates the matches and returns the updated matches';
 
 grant select on table app.match to app_anonymous, app_user, app_admin, app_meal_designer;
 grant insert, update, delete on table app.match to app_meal_designer, app_admin;

--- a/backend/start_postgraphile.sh
+++ b/backend/start_postgraphile.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 # test for the presence of the schema
-export PGPASSWORD=${POSTGRES_PASSWORD}
+# export PGPASSWORD=${POSTGRES_PASSWORD}
 
-sleep 5
+# sleep 5
 
-psql -U postgres -h db  -c "select count(*) from app_private.account"
-if [ $? != 0 ] || [ -f .reset-db ]; then
-	psql -U postgres -h db -f db-reset.psql
-fi
-rm -f .reset-db
-# run through the migrations
-for sql in migrations/*.sql
-do
-	psql -U postgres -h db  -f "${sql}"
-done
+# psql -U postgres -h db  -c "select count(*) from app_private.account"
+# if [ $? != 0 ] || [ -f .reset-db ]; then
+# 	psql -U postgres -h db -f db-reset.psql
+# fi
+# rm -f .reset-db
+# # run through the migrations
+# for sql in migrations/*.sql
+# do
+# 	psql -U postgres -h db  -f "${sql}"
+# done
+
 node server.js

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,6 +9,26 @@ services:
       - pgdata:/var/lib/postgresql/data
     env_file:
       - .env
+  migrator:
+    image: migrate/migrate
+    restart: 'no'
+    volumes:
+      - ./backend/db_migrations:/migrations
+    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/mpshadow?sslmode=disable"]
+    env_file:
+      - .env
+    depends_on: ['db']
+    links: ['db']
+  create-migration:
+    image: migrate/migrate
+    restart: 'no'
+    volumes:
+      - ./backend/db_migrations:/migrations
+    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/mpshadow?sslmode=disable", "create", "-dir", "/migrations", "-ext", "sql", "-seq"]
+    env_file:
+      - .env
+    depends_on: ['db']
+    links: ['db']
   graphql:
     build:
       context: backend

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,7 +14,7 @@ services:
     restart: 'no'
     volumes:
       - ./backend/db_migrations:/migrations
-    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/mpshadow?sslmode=disable"]
+    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/postgres?sslmode=disable"]
     env_file:
       - .env
     depends_on: ['db']
@@ -24,7 +24,7 @@ services:
     restart: 'no'
     volumes:
       - ./backend/db_migrations:/migrations
-    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/mpshadow?sslmode=disable", "create", "-dir", "/migrations", "-ext", "sql", "-seq"]
+    entrypoint: ["migrate", "-path", "/migrations", "-database", "postgres://postgres:$POSTGRES_PASSWORD@db/postgres?sslmode=disable", "create", "-dir", "/migrations", "-ext", "sql", "-seq"]
     env_file:
       - .env
     depends_on: ['db']

--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -16,116 +16,117 @@ import { ShoppingListQuery } from "./__generated__/ShoppingListQuery.graphql";
 import { Print } from "@mui/icons-material";
 import moment from "moment";
 
-const query = graphql`
-  query ShoppingListQuery($rowId: BigInt!) {
-    # mealPlan (id:"WyJtZWFscyIsMV0="){
-    mealPlan(rowId: $rowId) {
-      nameEn
-      descriptionEn
-      person {
-        fullName
-      }
-      shoppingList {
-        nodes {
-          unit
-          quantity
-          productId
-          productName
-          product {
-            price
-            quantity
-            unit
-          }
-        }
-      }
-    }
-  }
-`;
+// const query = graphql`
+//   query ShoppingListQuery($rowId: BigInt!) {
+//     # mealPlan (id:"WyJtZWFscyIsMV0="){
+//     mealPlan(rowId: $rowId) {
+//       nameEn
+//       descriptionEn
+//       person {
+//         fullName
+//       }
+//       shoppingList {
+//         nodes {
+//           unit
+//           quantity
+//           productId
+//           productName
+//           product {
+//             price
+//             quantity
+//             unit
+//           }
+//         }
+//       }
+//     }
+//   }
+// `;
 
 export const ShoppingList = () => {
-  const { id } = useParams();
-  console.log("trying ShoppingList");
-  const data = useLazyLoadQuery<ShoppingListQuery>(query, { rowId: id });
-  const { mealPlan } = data;
-  let totalPrice = 0;
-  if (mealPlan == null || mealPlan == undefined) {
-    return <p>Meal plan is not found.</p>;
-  }
+  return <div>Under construction 🚧</div>
+  // const { id } = useParams();
+  // console.log("trying ShoppingList");
+  // const data = useLazyLoadQuery<ShoppingListQuery>(query, { rowId: id });
+  // const { mealPlan } = data;
+  // let totalPrice = 0;
+  // if (mealPlan == null || mealPlan == undefined) {
+  //   return <p>Meal plan is not found.</p>;
+  // }
 
-  mealPlan.shoppingList.nodes.forEach((item) => {
-    totalPrice += Number(item.product?.price);
-  });
+  // mealPlan.shoppingList.nodes.forEach((item) => {
+  //   totalPrice += Number(item.product?.price);
+  // });
 
-  return (
-    <>
-      <Grid container spacing="5" sx={{ padding: "2rem" }}>
-        <Grid xs={12}>
-          <Typography variant="caption" sx={{ mr: 5 }}>
-            {mealPlan.person && `Prepared for ${mealPlan.person.fullName}`}
-          </Typography>
-          <Typography variant="caption">
-            Week {moment().startOf("week").format("MMMM DD")} -{" "}
-            {moment().endOf("week").format("MMMM DD")}
-          </Typography>
-        </Grid>
+  // return (
+  //   <>
+  //     <Grid container spacing="5" sx={{ padding: "2rem" }}>
+  //       <Grid xs={12}>
+  //         <Typography variant="caption" sx={{ mr: 5 }}>
+  //           {mealPlan.person && `Prepared for ${mealPlan.person.fullName}`}
+  //         </Typography>
+  //         <Typography variant="caption">
+  //           Week {moment().startOf("week").format("MMMM DD")} -{" "}
+  //           {moment().endOf("week").format("MMMM DD")}
+  //         </Typography>
+  //       </Grid>
 
-        <Grid item xs={8}>
-          <Typography variant="h4">
-            {mealPlan.nameEn} <br />
-            Shopping List &nbsp;
-            <Button
-              onClick={() => {
-                window.print();
-              }}
-            >
-              <Print></Print>
-            </Button>
-          </Typography>
-        </Grid>
-        <Grid item xs={4}>
-          <Typography sx={{ textAlign: "center" }}>
-            Estimate
-            <Typography variant="h2">${totalPrice.toFixed(2)}</Typography>
-          </Typography>
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="caption">{mealPlan.descriptionEn}</Typography>
-        </Grid>
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell style={{ color: "#000" }}>Bought?</TableCell>
-                <TableCell style={{ color: "#000" }}>
-                  Item/Description
-                </TableCell>
-                <TableCell style={{ color: "#000" }}>Quantity/Unit</TableCell>
-                <TableCell style={{ color: "#000" }}>Price</TableCell>
-              </TableRow>
-            </TableHead>
-            {/* <ul className={classes.ul}> */}
-            {mealPlan.shoppingList.nodes.map(function (item) {
-              return (
-                <TableRow key={item.productId}>
-                  <TableCell>
-                    <Checkbox checked={false} />
-                  </TableCell>
-                  <TableCell>
-                    {item.productName}
-                    <p>
-                      {item.quantity} {item.unit}
-                    </p>
-                  </TableCell>
-                  <TableCell>
-                    {item.product?.quantity} {item.product?.unit}
-                  </TableCell>
-                  <TableCell>{item.product?.price}</TableCell>
-                </TableRow>
-              );
-            })}
-          </Table>
-        </TableContainer>
-      </Grid>
-    </>
-  );
+  //       <Grid item xs={8}>
+  //         <Typography variant="h4">
+  //           {mealPlan.nameEn} <br />
+  //           Shopping List &nbsp;
+  //           <Button
+  //             onClick={() => {
+  //               window.print();
+  //             }}
+  //           >
+  //             <Print></Print>
+  //           </Button>
+  //         </Typography>
+  //       </Grid>
+  //       <Grid item xs={4}>
+  //         <Typography sx={{ textAlign: "center" }}>
+  //           Estimate
+  //           <Typography variant="h2">${totalPrice.toFixed(2)}</Typography>
+  //         </Typography>
+  //       </Grid>
+  //       <Grid item xs={12}>
+  //         <Typography variant="caption">{mealPlan.descriptionEn}</Typography>
+  //       </Grid>
+  //       <TableContainer>
+  //         <Table>
+  //           <TableHead>
+  //             <TableRow>
+  //               <TableCell style={{ color: "#000" }}>Bought?</TableCell>
+  //               <TableCell style={{ color: "#000" }}>
+  //                 Item/Description
+  //               </TableCell>
+  //               <TableCell style={{ color: "#000" }}>Quantity/Unit</TableCell>
+  //               <TableCell style={{ color: "#000" }}>Price</TableCell>
+  //             </TableRow>
+  //           </TableHead>
+  //           {/* <ul className={classes.ul}> */}
+  //           {mealPlan.shoppingList.nodes.map(function (item) {
+  //             return (
+  //               <TableRow key={item.productId}>
+  //                 <TableCell>
+  //                   <Checkbox checked={false} />
+  //                 </TableCell>
+  //                 <TableCell>
+  //                   {item.productName}
+  //                   <p>
+  //                     {item.quantity} {item.unit}
+  //                   </p>
+  //                 </TableCell>
+  //                 <TableCell>
+  //                   {item.product?.quantity} {item.product?.unit}
+  //                 </TableCell>
+  //                 <TableCell>{item.product?.price}</TableCell>
+  //               </TableRow>
+  //             );
+  //           })}
+  //         </Table>
+  //       </TableContainer>
+  //     </Grid>
+  //   </>
+  // );
 };


### PR DESCRIPTION
**Describe the technical changes contained in this PR**

We have been handrolling migrations and left it to the discretion of the developer to write a defensive migration. This will affect us in the long run. This PR implements the golang migrate tool.

https://github.com/golang-migrate/migrate

**Previous behaviour**
Migrations and structure changes were always rerun. Developers did not have a lot of control to migrate up or down.

**New behaviour**
With the migration tool a migration is run only once and can also be rolled back. We still use plain SQL for tracking migrations. Rather than timestamp based versions, we are using sequence based files just like the previous approaches.

**Have the following been addressed?**
- [x] Have test cases been created for all of the changes?
- [x] Do all of the test cases pass?
- [x] Has the testing been done using the default docker-compose environment?
- [x] Are documentation changes required?
- [x] Does this change break or alter existing behaviour?

