### PR TITLE
[#529] - adding prep time, cook time and portions to Meal page. Delet…

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -28,33 +28,17 @@ const mealQuery = graphql`
       photoUrl
       videoUrl
       method
-      cookingDuration
       totalCost
       servingCost
       tips
       servingsSize
       servingsSizeUnit
-      serves
+      prepTime
+      cookTime
+      portions
       nutritionRating
-      measures {
-        nodes {
-          id
-          product {
-            nameEn
-          }
-          unit
-          quantity
-        }
-      }
       nutrition {
         id
-      }
-      products {
-        edges {
-          node {
-            id
-          }
-        }
       }
     }
   }
@@ -226,8 +210,8 @@ export const Meal = () => {
               {meal?.nutritionRating}
             </Typography>
             <Typography variant="caption">
-              Meal Code: {meal?.code} &nbsp; Cooking Duration:{" "}
-              {meal?.cookingDuration} mins &nbsp; Serves: {meal?.serves} &nbsp;
+              Meal Code: {meal?.code} &nbsp; Prep Time:{" "} {meal?.prepTime} mins &nbsp; 
+              Cook Time:{" "} {meal?.cookTime} mins &nbsp; Portions: {meal?.portions} &nbsp;
               Serving Size: {meal?.servingsSize} {meal?.servingsSizeUnit} &nbsp;
               Serving Cost: {meal?.servingCost}$
             </Typography>
@@ -247,14 +231,6 @@ export const Meal = () => {
           </Grid>
           <Grid item xs={3}>
             <Typography variant="h6"> Ingredients </Typography>
-            <Typography>
-              {meal?.measures.nodes.map((ingredient) => (
-                <div>
-                  {ingredient.product?.nameEn} - {ingredient.quantity}{" "}
-                  {ingredient.unit}{" "}
-                </div>
-              ))}
-            </Typography>
           </Grid>
           <Grid item xs={9}>
             <Typography variant="h6"> Method of preparation </Typography>

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a110771a235e2ba05fff5bedb2047221>>
+ * @generated SignedSource<<78d29ec4a81454feb42e42c49bb764ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,7 @@ export type MealQuery$variables = {
 export type MealQuery$data = {
   readonly meal: {
     readonly rowId: any;
-    readonly code: string;
+    readonly code: any | null;
     readonly nameEn: string;
     readonly nameFr: string | null;
     readonly tags: ReadonlyArray<string | null> | null;
@@ -26,34 +26,18 @@ export type MealQuery$data = {
     readonly photoUrl: string | null;
     readonly videoUrl: string | null;
     readonly method: string | null;
-    readonly cookingDuration: any | null;
     readonly totalCost: any | null;
     readonly servingCost: any | null;
     readonly tips: string | null;
     readonly servingsSize: any | null;
     readonly servingsSizeUnit: string | null;
-    readonly serves: any | null;
+    readonly prepTime: any | null;
+    readonly cookTime: any | null;
+    readonly portions: any | null;
     readonly nutritionRating: number | null;
-    readonly measures: {
-      readonly nodes: ReadonlyArray<{
-        readonly id: string;
-        readonly product: {
-          readonly nameEn: string;
-        } | null;
-        readonly unit: string;
-        readonly quantity: any;
-      }>;
-    };
     readonly nutrition: {
       readonly id: string;
     } | null;
-    readonly products: {
-      readonly edges: ReadonlyArray<{
-        readonly node: {
-          readonly id: string;
-        };
-      }>;
-    };
   } | null;
 };
 export type MealQuery = {
@@ -157,121 +141,81 @@ v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cookingDuration",
+  "name": "totalCost",
   "storageKey": null
 },
 v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "totalCost",
+  "name": "servingCost",
   "storageKey": null
 },
 v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingCost",
+  "name": "tips",
   "storageKey": null
 },
 v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "tips",
+  "name": "servingsSize",
   "storageKey": null
 },
 v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingsSize",
+  "name": "servingsSizeUnit",
   "storageKey": null
 },
 v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "servingsSizeUnit",
+  "name": "prepTime",
   "storageKey": null
 },
 v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "serves",
+  "name": "cookTime",
   "storageKey": null
 },
 v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "nutritionRating",
+  "name": "portions",
   "storageKey": null
 },
 v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "nutritionRating",
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "unit",
+  "name": "id",
   "storageKey": null
 },
 v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "quantity",
-  "storageKey": null
-},
-v24 = [
-  (v21/*: any*/)
-],
-v25 = {
   "alias": null,
   "args": null,
   "concreteType": "Nutrition",
   "kind": "LinkedField",
   "name": "nutrition",
   "plural": false,
-  "selections": (v24/*: any*/),
-  "storageKey": null
-},
-v26 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "ProductsConnection",
-  "kind": "LinkedField",
-  "name": "products",
-  "plural": false,
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "ProductsEdge",
-      "kind": "LinkedField",
-      "name": "edges",
-      "plural": true,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "Product",
-          "kind": "LinkedField",
-          "name": "node",
-          "plural": false,
-          "selections": (v24/*: any*/),
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    }
+    (v22/*: any*/)
   ],
   "storageKey": null
 };
@@ -309,45 +253,8 @@ return {
           (v18/*: any*/),
           (v19/*: any*/),
           (v20/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "MeasuresConnection",
-            "kind": "LinkedField",
-            "name": "measures",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Measure",
-                "kind": "LinkedField",
-                "name": "nodes",
-                "plural": true,
-                "selections": [
-                  (v21/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Product",
-                    "kind": "LinkedField",
-                    "name": "product",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v22/*: any*/),
-                  (v23/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          (v25/*: any*/),
-          (v26/*: any*/)
+          (v21/*: any*/),
+          (v23/*: any*/)
         ],
         "storageKey": null
       }
@@ -388,63 +295,25 @@ return {
           (v18/*: any*/),
           (v19/*: any*/),
           (v20/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "MeasuresConnection",
-            "kind": "LinkedField",
-            "name": "measures",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Measure",
-                "kind": "LinkedField",
-                "name": "nodes",
-                "plural": true,
-                "selections": [
-                  (v21/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Product",
-                    "kind": "LinkedField",
-                    "name": "product",
-                    "plural": false,
-                    "selections": [
-                      (v4/*: any*/),
-                      (v21/*: any*/)
-                    ],
-                    "storageKey": null
-                  },
-                  (v22/*: any*/),
-                  (v23/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          (v25/*: any*/),
-          (v26/*: any*/),
-          (v21/*: any*/)
+          (v21/*: any*/),
+          (v23/*: any*/),
+          (v22/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7d2b9fef4db2b12e4a694c1119b01eb1",
+    "cacheID": "3d9fc0e35ce6a7a7e60d38e8d39a8310",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    cookingDuration\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    serves\n    nutritionRating\n    measures {\n      nodes {\n        id\n        product {\n          nameEn\n          id\n        }\n        unit\n        quantity\n      }\n    }\n    nutrition {\n      id\n    }\n    products {\n      edges {\n        node {\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2eb11b0b1b5d5a6601296931e78df327";
+(node as any).hash = "c7f547edb0feb149d3e0f574c4c37db6";
 
 export default node;


### PR DESCRIPTION
…ed Products and measure from meal query

*Describe the technical changes contained in this PR**
I made changes to the mealplanner-ui to reflect the backend meal table changes. Where we have new columns 'prepTime', 'cookTime', and 'portions'. And we also now dont have columns 'cookingDuration', 'Product', and 'measure' anymore for meal table.

**Previous behaviour**
The 'Meals' page wouldnt display because of the breaking chnages to the meal table.

**New behaviour**
The 'Meals' page now reflect the changes to the meal table. Now, once a user/admin/designer selects a meal to look at the details of the meal, they will see 'Prep Time', 'Cook Time', and 'Portions'.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/e4d7eaf2-25fb-4369-b608-adf78af1e334)


**Related issues addressed by this PR**
Fixes #529

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?