### PR TITLE
[#584] - Product keywords and tags in product and tags in meal are allowed to have spaces in between words

### DIFF
--- a/admin-ui/src/Meals/MealForm.tsx
+++ b/admin-ui/src/Meals/MealForm.tsx
@@ -17,7 +17,7 @@ export const MealForm = () => {
         fullWidth
         parse={(values) => {
           if(values == '') return null;
-          return values.split(",").map((s: string) => s.trim())
+          return values.split(",").map((s: string) => s.trimStart())
         }}
         source="tags"
       />

--- a/admin-ui/src/Products/ProductForm.tsx
+++ b/admin-ui/src/Products/ProductForm.tsx
@@ -17,20 +17,18 @@ export const ProductForm = () => {
         fullWidth
         parse={(values) => {
           if (values == "") return null;
-          return values.split(",").map((s: string) => s.trim());
+          // return values.split(",").map((s: string) => s.trim());
+          return values.split(",").map((s:string) => s.trimStart());
         }}
         source="tags"
       />
+
       <TextInput
         defaultValue={null}
         fullWidth
-        format={(x) => {
-          console.log('product keyword values', x);
-          return x && x.join(", ")
-        }}
-        parse={(values) => {
+        parse={(values: string) => {
           if (values == "") return null;
-          return values.split(",").map((s: string) => s.trim());
+          return values.split(",").map((s: string) => s.trimStart());
         }}
         source="productKeywords"
       />


### PR DESCRIPTION

**Describe the technical changes contained in this PR**
Product keywords and tags in product and tags in meal are now allowed to have spaces in between the words

**Previous behaviour**
Spaces were not allowed in between words in tags and product keywords.

**New behaviour**
Spaces are allowed in between words in tags and product keywords.

**Related issues addressed by this PR**
Fixes #584 

**Have the following been addressed?**
- [ -] Have test cases been created for all of the changes?
- [x ] Do all of the test cases pass?
- [ x] Has the testing been done using the default docker-compose environment?
- [x ] Are documentation changes required?
- [ x] Does this change break or alter existing behaviour?

