### PR TITLE
[#459] - turning duplicate icon green on mouse hover

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -153,6 +153,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
                       e.stopPropagation();
                       duplicateMealPlan(connection, mealplan.rowId);
                     }}
+                    sx={{ "& :hover": { color: theme.palette.primary.main } }}
                   >
                     <ContentCopy />
                   </IconButton>


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added code to MealPlanCard.tsx so that the duplicate icon turns green on mouse hover.

**Previous behaviour**
When user hovers over the duplicate icon, the icon stayed grey.

**New behaviour**
When user hovers over the duplicate icon, the icon turns green

**Related issues addressed by this PR**
Additional fix for issue #459 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

