### PR TITLE
[#560] - specific meal is viewable without logging in

### DIFF
--- a/mealplanner-ui/src/App.tsx
+++ b/mealplanner-ui/src/App.tsx
@@ -102,9 +102,9 @@ function App() {
               path="/meals/:id"
               element={
                 <Suspense fallback={"loading inner..."}>
-                  <LoggedIn>
+                  {/* <LoggedIn> */}
                     <Meal />
-                  </LoggedIn>
+                  {/* <LoggedIn> */}
                 </Suspense>
               }
             />


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Commented out the Login constraint in App.tsx for the Meal page

**Previous behaviour**
going to a specific meal page failed when the person is not logged in.

**New behaviour**
going to a specific meal page displays the meal recipe even when the person is not logged in.

**Related issues addressed by this PR**
Fixes #560 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

