### PR TITLE
[#580] - when there is numerous meal tags, the meal tags are aligned …

### DIFF
--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -39,7 +39,7 @@ export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
 
   return (
     <Grid container direction="column" margin="0rem 2rem">
-      <Stack direction="row" spacing={1}>
+      <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', width: '100%' }}>
         {mealTags.allMealTags?.edges.map((edge, index) => {
           const node = edge?.node;
           if (node !== null && node !== undefined) {


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
added code to MealTags.tsx so that the meal tags wrap when the tags exceed the size of the meals page.

**Previous behaviour**
When there are numerous meal tags, the user has to scroll horizontally to see all the meal tags.

**New behaviour**
The tags are aligned properly, so the user doesnt have to sctoll horizontally.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/1542ddd8-f1c6-4152-ae99-3a9e595897aa)


**Related issues addressed by this PR**
Fixes #580 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

