### PR TITLE
580 align meal tags and adjust Meal planner app bar for larger screen sizes

### DIFF
--- a/mealplanner-ui/src/layouts/ResponsiveAppBar.tsx
+++ b/mealplanner-ui/src/layouts/ResponsiveAppBar.tsx
@@ -50,8 +50,8 @@ const ResponsiveAppBar = () => {
   };
 
   return (
-    <AppBar position="static">
-      <Container maxWidth="xl" sx={{ backgroundColor: "#212121" }}>
+    <AppBar position="static" sx={{ backgroundColor: "#212121", width: '100%' }}>
+      <Container maxWidth={false}>
         <Toolbar disableGutters>
           <Typography
             variant="h6"

--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -39,7 +39,7 @@ export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
 
   return (
     <Grid container direction="column" margin="0rem 2rem">
-      <Stack direction="row" spacing={1}>
+      <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', width: '100%' }}>
         {mealTags.allMealTags?.edges.map((edge, index) => {
           const node = edge?.node;
           if (node !== null && node !== undefined) {


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Set the MUI Container maxWidth to false as it was preventing the app bar from adjusting for larger screen sizes. Added code to MealTags.tsx to properly stack the meal tags.

**Previous behaviour**
When the user/admin/meal designer sees the meal planner app bar on bigger screens, the app bar size does not adjust correctly. As well, the numerous meal tags displays out of the screen in one straight line. Which makes the user/admin/meal designer horizontal scroll.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/f31a9516-c5ca-4671-9144-be14c10d9d78)


**New behaviour**
When the user/admin/meal designer sees the meal planner app bar on bigger screens, the app bar size adjusts correctly, and there is no more green bars on either side of the app bar. As well, numerous meal tags are nicely stacked so that the user/admin/meal designer does not have to horizontal scroll to view all meal tags.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/d10aad20-dae7-46ab-9140-b984b030c692)


**Related issues addressed by this PR**
Fixes #580 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

