### PR TITLE
595-[BUG] When we try to create an ingredient we get an error

### DIFF
--- a/admin-ui/src/Ingredients/IngredientCreate.tsx
+++ b/admin-ui/src/Ingredients/IngredientCreate.tsx
@@ -6,6 +6,7 @@ import {
   ReferenceInput,
   SimpleForm,
   TextInput,
+  required,
   useGetOne,
 } from "react-admin";
 import { useParams } from "react-router-dom";
@@ -29,20 +30,22 @@ export const IngredientCreate = (props: CreateProps) => {
         sx={{
           display: "none",
         }}
-
+        validate={required()}
         />
         <NumberInput source="code" label="Ingredient Code" fullWidth min={1} /> 
-        <TextInput source="name" label="Ingredient Name" fullWidth />
-        <NumberInput source="quantity" fullWidth min={0} />
+        <TextInput source="name" label="Ingredient Name" fullWidth validate={required()}/>
+        <NumberInput source="quantity" fullWidth min={0} validate={required()}/>
         <TextInput
           source="unit"
           fullWidth
           helperText="Measure unit Eg: g, ml, cup, tsp"
+          validate={required()}
         />
         <TextInput
           source="productKeyword"
           fullWidth
           helperText="Search keyword for a buyer"
+          validate={required()}
         />
         <ReferenceInput source="substituteIngredientId" reference="ingredients">
           <AutocompleteInput


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Following the steps described in the test case [AA-IngredientCreationError-035](https://github.com/CivicTechFredericton/mealplanner/wiki/Test-case-portfolio-v1.0-and-2.0#test-case-id-AA-IngredientCreationError-035) will successfully create the ingredient. But there are errors when you don't provide values for the required fields in the form. The image below exemplifies this:

![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/99ea2294-a7a0-44ae-8f26-3a098148a987)

**Previous behaviour**
In the ingredient creation form, follow these steps:

1. provide the ingredient name field only
2. The save button turned blue
3. Click in save
4. An error is returned, and the ingredient is not saved

**New behaviour**
In the ingredient creation form, follow these steps:

1. provide a number in the ingredient code field only
2. The save button turned blue
3. Click in save
4. The required fields will turn red
5. An error message will inform that the form is not valid
6. The operation will not proceed

Filling in all the required information will allow the user to save the new ingredient in the database.

![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/2ab549cb-e0da-4b7b-83ed-18f709907380)


**Related issues addressed by this PR**
Fixes #595 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

