### PR TITLE
609 ingredients needs to be visible in meal page

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -329,8 +329,7 @@ export const Meal = () => {
                               <>
                                 {" "}
                                 <br />
-                                Substitute: {ingredient.substituteIngredient.name} <br />
-                                Reason: {ingredient.substituteIngredient.substituteReason}
+                                <span style={{fontStyle: "italic"}}>*Substitute: {ingredient.substituteIngredient.name}</span> <br />
                               </>
                             ) : (
                               <></>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -14,7 +14,7 @@ import { graphql } from "babel-plugin-relay/macro";
 import { useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import { MealQuery } from "./__generated__/MealQuery.graphql";
-import React from "react";
+import React, { useEffect } from "react";
 
 const mealQuery = graphql`
   query MealQuery($mealId: BigInt!) {
@@ -88,11 +88,6 @@ const mealQuery = graphql`
           name
           quantity
           unit
-          substituteIngredient {
-            name
-            quantity
-            unit
-          }
         }
       }
     }
@@ -100,6 +95,7 @@ const mealQuery = graphql`
 `;
 
 export const Meal = () => {
+  
   const params = useParams();
   const node = useLazyLoadQuery<MealQuery>(
     mealQuery,
@@ -135,6 +131,9 @@ export const Meal = () => {
       </span>
     ));
   };
+  useEffect(() => {
+    console.log(meal)
+  }, [meal])
   return (
     <>
       <Box
@@ -305,10 +304,10 @@ export const Meal = () => {
                         <tr>
                           <td style={{ textAlign: "left" }}>
                             {ingredient.name}
-                              <br />
+                              {/* <br />
                             {false && (
                               ingredient.name
-                            )}
+                            )} */}
                           </td>
                           <td style={{ textAlign: "center" }}>{ingredient.quantity}</td>
                           <td style={{ textAlign: "center", paddingLeft: "10px" }}> {ingredient.unit}

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -357,7 +357,7 @@ export const Meal = () => {
                               <></>
                             )}
                           </td>
-                          <td>
+                          <td style={{paddingLeft: "0.5rem"}}>
                             {ingredient.unit}
                             {ingredient.substituteIngredient ? (
                               <>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -332,14 +332,15 @@ export const Meal = () => {
                               <>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  *Substitute: {ingredient.substituteIngredient.name}
+                                  Substitute: {ingredient.substituteIngredient.name}
                                 </span>
                                 <br />
-                                {ingredient.substituteReason && (
-                                  <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                    *Reason: {ingredient.substituteReason}
-                                  </span>
-                                )}
+                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                  Reason:{" "}
+                                  {ingredient.substituteReason
+                                    ? ingredient.substituteReason
+                                    : "Not specified"}
+                                </span>
                               </>
                             ) : (
                               <></>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -14,7 +14,7 @@ import { graphql } from "babel-plugin-relay/macro";
 import { useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import { MealQuery } from "./__generated__/MealQuery.graphql";
-import React, { useEffect } from "react";
+import React from "react";
 
 const mealQuery = graphql`
   query MealQuery($mealId: BigInt!) {
@@ -150,11 +150,6 @@ export const Meal = () => {
       </span>
     ));
   };
-  useEffect(() => {
-    console.log(meal)
-    console.log(arrayOfSubstituteIngredientsIds)
-    console.log(arrayOfIngredientsWithoutSubstituteIngredients)
-  }, [meal])
   return (
     <>
       <Box
@@ -311,6 +306,10 @@ export const Meal = () => {
                 "#ingredientsTable td": {
                   verticalAlign: "top",
                 },
+                "#ingredientsTable span": {
+                  fontStyle: "italic",
+
+                }
               }}
             >
               <>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -309,7 +309,7 @@ export const Meal = () => {
                     <tr style={{backgroundColor: "#E8F5E9"}}>
                       <th style={{ textAlign: "left" }}>Ingredients</th>
                       <th style={{ textAlign: "center" }}>Qtt</th>
-                      <th style={{ textAlign: "center" }}>Unit</th>
+                      <th style={{ textAlign: "center", paddingLeft: "10px" }}>Unit</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -318,7 +318,7 @@ export const Meal = () => {
                         <tr>
                           <td style={{ textAlign: "left" }}>{ingredient.name}</td>
                           <td style={{ textAlign: "center" }}>{ingredient.quantity}</td>
-                          <td style={{ textAlign: "center" }}>{ingredient.unit}</td>
+                          <td style={{ textAlign: "center", paddingLeft: "10px" }}>{ingredient.unit}</td>
                         </tr>
                       );
                     })}

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -308,6 +308,9 @@ export const Meal = () => {
                 "#ingredientsTable thead": {
                   borderBottom: "1px solid black",
                 },
+                "#ingredientsTable td": {
+                  verticalAlign: "top",
+                },
               }}
             >
               <>
@@ -333,7 +336,7 @@ export const Meal = () => {
                                 </span>
                                 <br />
                                 {ingredient.substituteReason && (
-                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                  <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
                                     *Reason: {ingredient.substituteReason}
                                   </span>
                                 )}
@@ -342,31 +345,25 @@ export const Meal = () => {
                               <></>
                             )}
                           </td>
-                          <td style={{textAlign: "center"}}>
+                          <td style={{ textAlign: "center", verticalAlign: "top" }}>
                             {ingredient.quantity}
                             {ingredient.substituteIngredient ? (
                               <>
                                 <br />
                                 <span>{ingredient.substituteIngredient.quantity}</span>
                                 <br />
-                                {ingredient.substituteReason && (
-                                  <span style={{ color: "#E8F5E9" }}>{" - "}</span>
-                                )}
                               </>
                             ) : (
                               <></>
                             )}
                           </td>
-                          <td style={{paddingLeft: "0.5rem"}}>
+                          <td style={{ paddingLeft: "0.5rem" }}>
                             {ingredient.unit}
                             {ingredient.substituteIngredient ? (
                               <>
                                 <br />
                                 <span>{ingredient.substituteIngredient.unit}</span>
                                 <br />
-                                {ingredient.substituteReason && (
-                                  <span style={{ color: "#E8F5E9" }}>{" - "}</span>
-                                )}
                               </>
                             ) : (
                               <></>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -91,12 +91,12 @@ const mealQuery = graphql`
           quantity
           unit
           substituteIngredientId
+          substituteReason
           substituteIngredient {
             id
             name
             quantity
             unit
-            substituteReason
           }
         }
       }
@@ -299,7 +299,7 @@ export const Meal = () => {
               variant="body1"
               sx={{
                 "#ingredientsTable tbody tr:nth-of-type(even)": {
-                  backgroundColor: "#E8F5E9" /* Slightly darker gray for odd rows */,
+                  backgroundColor: "#E8F5E9" /* Slightly darker green for even rows */,
                 },
                 "#ingredientsTable": {
                   border: "1px solid #E0E0E0",
@@ -316,7 +316,7 @@ export const Meal = () => {
                     <tr style={{ backgroundColor: "#E8F5E9" }}>
                       <th style={{ textAlign: "left" }}>Ingredients</th>
                       <th style={{ textAlign: "center" }}>Qtt</th>
-                      <th style={{ textAlign: "center", paddingLeft: "10px" }}>Unit</th>
+                      <th style={{ textAlign: "center" }}>Unit</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -327,20 +327,31 @@ export const Meal = () => {
                             {ingredient.name}
                             {ingredient.substituteIngredient ? (
                               <>
-                                {" "}
                                 <br />
-                                <span style={{fontStyle: "italic"}}>*Substitute: {ingredient.substituteIngredient.name}</span> <br />
+                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                  *Substitute: {ingredient.substituteIngredient.name}
+                                </span>
+                                <br />
+                                {ingredient.substituteReason && (
+                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                    *Reason: {ingredient.substituteReason}
+                                  </span>
+                                )}
                               </>
                             ) : (
                               <></>
                             )}
                           </td>
-                          <td>
+                          <td style={{textAlign: "center"}}>
                             {ingredient.quantity}
                             {ingredient.substituteIngredient ? (
                               <>
-                                {" "}
-                                <br /> {ingredient.substituteIngredient.quantity}{" "}
+                                <br />
+                                <span>{ingredient.substituteIngredient.quantity}</span>
+                                <br />
+                                {ingredient.substituteReason && (
+                                  <span style={{ color: "#E8F5E9" }}>{" - "}</span>
+                                )}
                               </>
                             ) : (
                               <></>
@@ -350,7 +361,12 @@ export const Meal = () => {
                             {ingredient.unit}
                             {ingredient.substituteIngredient ? (
                               <>
-                                <br /> {ingredient.substituteIngredient.unit}{" "}
+                                <br />
+                                <span>{ingredient.substituteIngredient.unit}</span>
+                                <br />
+                                {ingredient.substituteReason && (
+                                  <span style={{ color: "#E8F5E9" }}>{" - "}</span>
+                                )}
                               </>
                             ) : (
                               <></>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -82,6 +82,14 @@ const mealQuery = graphql`
         vitD
         vitE
         vitK
+
+      }
+      ingredients {
+        nodes {
+          name
+          quantity
+          unit
+        }
       }
     }
   }
@@ -123,6 +131,15 @@ export const Meal = () => {
       </span>
     ));
   };
+
+
+  useEffect(() => {
+    console.log(meal)
+  
+  }, [meal])
+  
+
+
   return (
     <>
       <Box

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -82,13 +82,17 @@ const mealQuery = graphql`
         vitD
         vitE
         vitK
-
       }
       ingredients {
         nodes {
           name
           quantity
           unit
+          substituteIngredient {
+            name
+            quantity
+            unit
+          }
         }
       }
     }
@@ -170,36 +174,28 @@ export const Meal = () => {
           </Typography>
         </Paper>
         <Tooltip title={nutritionData}>
-        <Paper
-          sx={{
-            textAlign: "center",
-            width: "160px",
-            opacity: "0.7",
-            position: "absolute",
-            right: 50,
-            top: 250,
-            backgroundColor: "black",
-          }}
-        >
-          <Typography variant="caption" color="whitesmoke">
-            Nutrition rating
-          </Typography>
-          <Rating
-            name="read-only"
-            value={
-              meal?.nutritionRating === undefined ? null : meal?.nutritionRating
-            }
-            readOnly
-          />
-        </Paper>
+          <Paper
+            sx={{
+              textAlign: "center",
+              width: "160px",
+              opacity: "0.7",
+              position: "absolute",
+              right: 50,
+              top: 250,
+              backgroundColor: "black",
+            }}
+          >
+            <Typography variant="caption" color="whitesmoke">
+              Nutrition rating
+            </Typography>
+            <Rating
+              name="read-only"
+              value={meal?.nutritionRating === undefined ? null : meal?.nutritionRating}
+              readOnly
+            />
+          </Paper>
         </Tooltip>
-        <Typography
-          variant="body1"
-          lineHeight="2rem"
-          position="absolute"
-          top="300px"
-          left="50px"
-        >
+        <Typography variant="body1" lineHeight="2rem" position="absolute" top="300px" left="50px">
           {displayTags()}
         </Typography>
       </Box>
@@ -254,24 +250,17 @@ export const Meal = () => {
                 </span>
               ))}
             </Typography>
-            <Typography
-              variant="body1"
-              sx={{ display: "none", displayPrint: "block" }}
-            >
+            <Typography variant="body1" sx={{ display: "none", displayPrint: "block" }}>
               {displayTags()}
             </Typography>
-            <Typography
-              variant="body1"
-              sx={{ display: "none", displayPrint: "block" }}
-            >
-              Estimated Price: {displayCost()} Nutrition Rating:{" "}
-              {meal?.nutritionRating}
+            <Typography variant="body1" sx={{ display: "none", displayPrint: "block" }}>
+              Estimated Price: {displayCost()} Nutrition Rating: {meal?.nutritionRating}
             </Typography>
             <Typography variant="caption">
-              Meal Code: {meal?.code} &nbsp; Prep Time:{" "} {meal?.prepTime} mins &nbsp; 
-              Cook Time:{" "} {meal?.cookTime} mins &nbsp; Portions: {meal?.portions} &nbsp;
-              Serving Size: {meal?.servingsSize} {meal?.servingsSizeUnit} &nbsp;
-              Serving Cost: {meal?.servingCost}$
+              Meal Code: {meal?.code} &nbsp; Prep Time: {meal?.prepTime} mins &nbsp; Cook Time:{" "}
+              {meal?.cookTime} mins &nbsp; Portions: {meal?.portions} &nbsp; Serving Size:{" "}
+              {meal?.servingsSize} {meal?.servingsSizeUnit} &nbsp; Serving Cost: {meal?.servingCost}
+              $
             </Typography>
 
             {/* Explicitly indicate meal description is not available*/}
@@ -281,9 +270,7 @@ export const Meal = () => {
                 {meal.descriptionEn}{" "}
               </Typography>
             ) : (
-              <Typography color="gray">
-                No meal description available
-              </Typography>
+              <Typography color="gray">No meal description available</Typography>
             )}
             <Typography paddingBottom="1em">{meal?.descriptionFr}</Typography>
           </Grid>
@@ -306,7 +293,7 @@ export const Meal = () => {
               <>
                 <table id="ingredientsTable" cellSpacing="0" cellPadding="0">
                   <thead>
-                    <tr style={{backgroundColor: "#E8F5E9"}}>
+                    <tr style={{ backgroundColor: "#E8F5E9" }}>
                       <th style={{ textAlign: "left" }}>Ingredients</th>
                       <th style={{ textAlign: "center" }}>Qtt</th>
                       <th style={{ textAlign: "center", paddingLeft: "10px" }}>Unit</th>
@@ -316,9 +303,16 @@ export const Meal = () => {
                     {meal?.ingredients?.nodes?.map((ingredient) => {
                       return (
                         <tr>
-                          <td style={{ textAlign: "left" }}>{ingredient.name}</td>
+                          <td style={{ textAlign: "left" }}>
+                            {ingredient.name}
+                              <br />
+                            {false && (
+                              ingredient.name
+                            )}
+                          </td>
                           <td style={{ textAlign: "center" }}>{ingredient.quantity}</td>
-                          <td style={{ textAlign: "center", paddingLeft: "10px" }}>{ingredient.unit}</td>
+                          <td style={{ textAlign: "center", paddingLeft: "10px" }}> {ingredient.unit}
+                          </td>
                         </tr>
                       );
                     })}

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -131,15 +131,6 @@ export const Meal = () => {
       </span>
     ));
   };
-
-
-  useEffect(() => {
-    console.log(meal)
-  
-  }, [meal])
-  
-
-
   return (
     <>
       <Box
@@ -298,6 +289,44 @@ export const Meal = () => {
           </Grid>
           <Grid item xs={3}>
             <Typography variant="h6"> Ingredients </Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                "#ingredientsTable tbody tr:nth-child(odd)": {
+                  backgroundColor: "#EEEEEE" /* Slightly darker gray for odd rows */,
+                },
+                "#ingredientsTable": {
+                  border: "1px solid #E0E0E0",
+                  padding: "0.3em",
+                },
+                "#ingredientsTable thead": {
+                  borderBottom: "1px solid black",
+                },
+              }}
+            >
+              <>
+                <table id="ingredientsTable" cellSpacing="0" cellPadding="0">
+                  <thead>
+                    <tr>
+                      <th style={{ textAlign: "left" }}>Name</th>
+                      <th style={{ textAlign: "center" }}>Qtt</th>
+                      <th style={{ textAlign: "center" }}>Unit</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {meal?.ingredients?.nodes?.map((ingredient) => {
+                      return (
+                        <tr>
+                          <td style={{ textAlign: "left" }}>{ingredient.name}</td>
+                          <td style={{ textAlign: "center" }}>{ingredient.quantity}</td>
+                          <td style={{ textAlign: "center" }}>{ingredient.unit}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </>
+            </Typography>
           </Grid>
           <Grid item xs={9}>
             <Typography variant="h6"> Method of preparation </Typography>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -85,9 +85,19 @@ const mealQuery = graphql`
       }
       ingredients {
         nodes {
+          rowId
+          id
           name
           quantity
           unit
+          substituteIngredientId
+          substituteIngredient {
+            id
+            name
+            quantity
+            unit
+            substituteReason
+          }
         }
       }
     }
@@ -107,6 +117,15 @@ export const Meal = () => {
   const nutritionData = data
   ? Object.entries(data).filter(([key, value]) => value !== null).map(([key, value]) => <React.Fragment>{key}: {value}<br /></React.Fragment>)
   : 'No data';
+
+  const arrayOfSubstituteIngredientsIds = meal?.ingredients?.nodes
+    ?.filter((item) => item?.substituteIngredientId)
+    .map((item) => item?.substituteIngredientId);
+
+  const arrayOfIngredientsWithoutSubstituteIngredients = meal?.ingredients?.nodes?.filter(
+    (item) => !arrayOfSubstituteIngredientsIds?.includes(item.rowId) 
+  );
+  
   
   const theme = useTheme();
   const tagStyle = {
@@ -133,6 +152,8 @@ export const Meal = () => {
   };
   useEffect(() => {
     console.log(meal)
+    console.log(arrayOfSubstituteIngredientsIds)
+    console.log(arrayOfIngredientsWithoutSubstituteIngredients)
   }, [meal])
   return (
     <>
@@ -277,7 +298,7 @@ export const Meal = () => {
             <Typography
               variant="body1"
               sx={{
-                "#ingredientsTable tbody tr:nth-child(even)": {
+                "#ingredientsTable tbody tr:nth-of-type(even)": {
                   backgroundColor: "#E8F5E9" /* Slightly darker gray for odd rows */,
                 },
                 "#ingredientsTable": {
@@ -299,19 +320,44 @@ export const Meal = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {meal?.ingredients?.nodes?.map((ingredient) => {
+                    {arrayOfIngredientsWithoutSubstituteIngredients?.map((ingredient) => {
                       return (
-                        <tr>
-                          <td style={{ textAlign: "left" }}>
+                        <tr key={ingredient.id}>
+                          <td>
                             {ingredient.name}
-                              {/* <br />
-                            {false && (
-                              ingredient.name
-                            )} */}
+                            {ingredient.substituteIngredient ? (
+                              <>
+                                {" "}
+                                <br />
+                                Substitute: {ingredient.substituteIngredient.name} <br />
+                                Reason: {ingredient.substituteIngredient.substituteReason}
+                              </>
+                            ) : (
+                              <></>
+                            )}
                           </td>
-                          <td style={{ textAlign: "center" }}>{ingredient.quantity}</td>
-                          <td style={{ textAlign: "center", paddingLeft: "10px" }}> {ingredient.unit}
+                          <td>
+                            {ingredient.quantity}
+                            {ingredient.substituteIngredient ? (
+                              <>
+                                {" "}
+                                <br /> {ingredient.substituteIngredient.quantity}{" "}
+                              </>
+                            ) : (
+                              <></>
+                            )}
                           </td>
+                          <td>
+                            {ingredient.unit}
+                            {ingredient.substituteIngredient ? (
+                              <>
+                                <br /> {ingredient.substituteIngredient.unit}{" "}
+                              </>
+                            ) : (
+                              <></>
+                            )}
+                          </td>
+                          <td></td>
                         </tr>
                       );
                     })}

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -288,12 +288,11 @@ export const Meal = () => {
             <Typography paddingBottom="1em">{meal?.descriptionFr}</Typography>
           </Grid>
           <Grid item xs={3}>
-            <Typography variant="h6"> Ingredients </Typography>
             <Typography
               variant="body1"
               sx={{
-                "#ingredientsTable tbody tr:nth-child(odd)": {
-                  backgroundColor: "#EEEEEE" /* Slightly darker gray for odd rows */,
+                "#ingredientsTable tbody tr:nth-child(even)": {
+                  backgroundColor: "#E8F5E9" /* Slightly darker gray for odd rows */,
                 },
                 "#ingredientsTable": {
                   border: "1px solid #E0E0E0",
@@ -307,8 +306,8 @@ export const Meal = () => {
               <>
                 <table id="ingredientsTable" cellSpacing="0" cellPadding="0">
                   <thead>
-                    <tr>
-                      <th style={{ textAlign: "left" }}>Name</th>
+                    <tr style={{backgroundColor: "#E8F5E9"}}>
+                      <th style={{ textAlign: "left" }}>Ingredients</th>
                       <th style={{ textAlign: "center" }}>Qtt</th>
                       <th style={{ textAlign: "center" }}>Unit</th>
                     </tr>

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0355d90dd25d726ecdcb8b6a26f8696a>>
+ * @generated SignedSource<<f546e3e6ed23ed96b88dd796dabf83e9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -546,6 +546,27 @@ v64 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v65 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "quantity",
+  "storageKey": null
+},
+v66 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "unit",
+  "storageKey": null
+},
+v67 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 };
@@ -634,6 +655,31 @@ return {
               (v61/*: any*/),
               (v62/*: any*/),
               (v63/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "IngredientsConnection",
+            "kind": "LinkedField",
+            "name": "ingredients",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Ingredient",
+                "kind": "LinkedField",
+                "name": "nodes",
+                "plural": true,
+                "selections": [
+                  (v64/*: any*/),
+                  (v65/*: any*/),
+                  (v66/*: any*/)
+                ],
+                "storageKey": null
+              }
             ],
             "storageKey": null
           }
@@ -728,27 +774,53 @@ return {
               (v61/*: any*/),
               (v62/*: any*/),
               (v63/*: any*/),
-              (v64/*: any*/)
+              (v67/*: any*/)
             ],
             "storageKey": null
           },
-          (v64/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "IngredientsConnection",
+            "kind": "LinkedField",
+            "name": "ingredients",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Ingredient",
+                "kind": "LinkedField",
+                "name": "nodes",
+                "plural": true,
+                "selections": [
+                  (v64/*: any*/),
+                  (v65/*: any*/),
+                  (v66/*: any*/),
+                  (v67/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v67/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "a9c5f5ba4ee7da31dfc9d8c2b11eb7ee",
+    "cacheID": "e6d69d42ba9aa33cd41b420c4543e581",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        name\n        quantity\n        unit\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1b5e0c2d163cfa76069d51b36639a663";
+(node as any).hash = "c4cbc91a35d3e4931a71f82da60ddb2e";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<56fe090cba3e6a478f7473a6fd37735c>>
+ * @generated SignedSource<<b7470015f474fc44bfa18e7be186edca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -87,12 +87,12 @@ export type MealQuery$data = {
         readonly quantity: any;
         readonly unit: string;
         readonly substituteIngredientId: any | null;
+        readonly substituteReason: ReadonlyArray<string | null> | null;
         readonly substituteIngredient: {
           readonly id: string;
           readonly name: string;
           readonly quantity: any;
           readonly unit: string;
-          readonly substituteReason: ReadonlyArray<string | null> | null;
         } | null;
       }>;
     };
@@ -611,6 +611,13 @@ v68 = {
         {
           "alias": null,
           "args": null,
+          "kind": "ScalarField",
+          "name": "substituteReason",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "Ingredient",
           "kind": "LinkedField",
           "name": "substituteIngredient",
@@ -619,14 +626,7 @@ v68 = {
             (v64/*: any*/),
             (v65/*: any*/),
             (v66/*: any*/),
-            (v67/*: any*/),
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "substituteReason",
-              "storageKey": null
-            }
+            (v67/*: any*/)
           ],
           "storageKey": null
         }
@@ -828,16 +828,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ec8df3759f24522c28d1d2a161b9e2e",
+    "cacheID": "0a1b3fa71be8350bd2fed80252ef5c1a",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        rowId\n        id\n        name\n        quantity\n        unit\n        substituteIngredientId\n        substituteIngredient {\n          id\n          name\n          quantity\n          unit\n          substituteReason\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        rowId\n        id\n        name\n        quantity\n        unit\n        substituteIngredientId\n        substituteReason\n        substituteIngredient {\n          id\n          name\n          quantity\n          unit\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a2d9e8438e53b421190f512a3d6ccee6";
+(node as any).hash = "07dcf53b75070a69fa8543a4ce875aef";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f546e3e6ed23ed96b88dd796dabf83e9>>
+ * @generated SignedSource<<56fe090cba3e6a478f7473a6fd37735c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -81,9 +81,19 @@ export type MealQuery$data = {
     } | null;
     readonly ingredients: {
       readonly nodes: ReadonlyArray<{
+        readonly rowId: any;
+        readonly id: string;
         readonly name: string;
         readonly quantity: any;
         readonly unit: string;
+        readonly substituteIngredientId: any | null;
+        readonly substituteIngredient: {
+          readonly id: string;
+          readonly name: string;
+          readonly quantity: any;
+          readonly unit: string;
+          readonly substituteReason: ReadonlyArray<string | null> | null;
+        } | null;
       }>;
     };
   } | null;
@@ -546,28 +556,84 @@ v64 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v65 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "quantity",
+  "name": "name",
   "storageKey": null
 },
 v66 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "unit",
+  "name": "quantity",
   "storageKey": null
 },
 v67 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "unit",
+  "storageKey": null
+},
+v68 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "IngredientsConnection",
+  "kind": "LinkedField",
+  "name": "ingredients",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Ingredient",
+      "kind": "LinkedField",
+      "name": "nodes",
+      "plural": true,
+      "selections": [
+        (v2/*: any*/),
+        (v64/*: any*/),
+        (v65/*: any*/),
+        (v66/*: any*/),
+        (v67/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "substituteIngredientId",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Ingredient",
+          "kind": "LinkedField",
+          "name": "substituteIngredient",
+          "plural": false,
+          "selections": [
+            (v64/*: any*/),
+            (v65/*: any*/),
+            (v66/*: any*/),
+            (v67/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "substituteReason",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
   "storageKey": null
 };
 return {
@@ -658,31 +724,7 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "IngredientsConnection",
-            "kind": "LinkedField",
-            "name": "ingredients",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Ingredient",
-                "kind": "LinkedField",
-                "name": "nodes",
-                "plural": true,
-                "selections": [
-                  (v64/*: any*/),
-                  (v65/*: any*/),
-                  (v66/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
+          (v68/*: any*/)
         ],
         "storageKey": null
       }
@@ -774,53 +816,28 @@ return {
               (v61/*: any*/),
               (v62/*: any*/),
               (v63/*: any*/),
-              (v67/*: any*/)
+              (v64/*: any*/)
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "IngredientsConnection",
-            "kind": "LinkedField",
-            "name": "ingredients",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Ingredient",
-                "kind": "LinkedField",
-                "name": "nodes",
-                "plural": true,
-                "selections": [
-                  (v64/*: any*/),
-                  (v65/*: any*/),
-                  (v66/*: any*/),
-                  (v67/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          (v67/*: any*/)
+          (v68/*: any*/),
+          (v64/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "e6d69d42ba9aa33cd41b420c4543e581",
+    "cacheID": "4ec8df3759f24522c28d1d2a161b9e2e",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        name\n        quantity\n        unit\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        rowId\n        id\n        name\n        quantity\n        unit\n        substituteIngredientId\n        substituteIngredient {\n          id\n          name\n          quantity\n          unit\n          substituteReason\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c4cbc91a35d3e4931a71f82da60ddb2e";
+(node as any).hash = "a2d9e8438e53b421190f512a3d6ccee6";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -79,6 +79,13 @@ export type MealQuery$data = {
       readonly vitE: any | null;
       readonly vitK: any | null;
     } | null;
+    readonly ingredients: {
+      readonly nodes: ReadonlyArray<{
+        readonly name: string;
+        readonly quantity: any;
+        readonly unit: string;
+      }>;
+    };
   } | null;
 };
 export type MealQuery = {


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Updated the Meal.tsx page to query the ingredients from the database and display the data in the appropriate section

**Previous behaviour**
No Ingredients were displayed in the Meal.tsx page.

**New behaviour**
The Meal.tsx page displays the names of the ingredients, quantities, and units for each meal.
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/b1896420-e3ae-422e-8ae5-3d37ebc9e669)


**Related issues addressed by this PR**
Fixes #609 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

