### PR TITLE
[#623]-removing favorites icon in mealplan card

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -196,13 +196,6 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
             </Typography>
           </CardContent>
           <CardActions disableSpacing>
-            <IconButton
-              aria-label="add to favorites"
-              sx={{ "& :hover": { color: theme.palette.secondary.dark } }}
-            >
-              <Favorite />
-            </IconButton>
-
             <ExpandMoreFn
               expand={expanded}
               onClick={handleExpandClick}


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Removed the favorites icon in MealPlanCard.tsx

**Previous behaviour**
Before, each mealplan card displayed a favorites icon

**New behaviour**
Now, the favorites icon is gone from mealplan card
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/357823bc-44a3-4e83-8060-0a3675da3ca2)

**Related issues addressed by this PR**
Fixes #623 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

