### PR TITLE
622 Meal Plan card

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -163,7 +163,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
               </div>
             }
             title={mealplan.nameEn}
-            subheader={mealplan.person?.fullName == null? "No User Assigned": mealplan.person?.fullName}
+            subheader={!mealplan.isTemplate && mealplan.person?.fullName == null? "No User Assigned": mealplan.person?.fullName}
           />
           {startDate && (
             <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -34,10 +34,8 @@ interface MealPlanCardProps {
   
 const getInitials = (name: string) => {
     let initials = "";
-    let names: string[] = (name && name.length > 1 && name.split(" ")) || [
-      "No",
-      "Name",
-    ];
+
+    let names: string[] = (name && name.length > 1 && name.split(" ")) || [];
     names.forEach((n) => {
       initials += n[0];
     });
@@ -92,9 +90,11 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
         >
           <CardHeader
             avatar={
-              <Avatar sx={{ bgcolor: "green", width: "fit" }} aria-label="user">
-                {getInitials(mealplan.person?.fullName || "")}
+              <Tooltip title={mealplan.isTemplate ? "Template" : ""}>
+              <Avatar sx={{ bgcolor: mealplan.isTemplate? "grey":"green", width: "fit" }} aria-label="user">
+                {mealplan.isTemplate ? "T" : getInitials(mealplan.person?.fullName || "")}
               </Avatar>
+              </Tooltip>
             }
             action={
               <div>
@@ -163,7 +163,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
               </div>
             }
             title={mealplan.nameEn}
-            subheader={mealplan.person?.fullName}
+            subheader={mealplan.person?.fullName == null? "No User Assigned": mealplan.person?.fullName}
           />
           {startDate && (
             <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>


### PR DESCRIPTION
![image](https://github.com/CivicTechFredericton/mealplanner/assets/97687268/cfbc32d5-f52c-463e-834f-4dc549ee9575)

**Describe the technical changes contained in this PR**
Modified MealPlanCard file to update the mealplan and template initials

**Previous behaviour**
Visually, there was no way to differentiate between Mealplan and template

**New behaviour**
Mealplan and template can be differentiated by looking at the gravator circle being grey with a letter 'T'  and a tooltip 'Template' for template and initials for mealplan. Also, the subheader for mealplan is now updated to 'No User Assigned' when no user is assigned to the mealplan.

**Related issues addressed by this PR**
Fixes #622 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

