### PR TITLE
603 adding price, disclaimer text, substitute ingredient, and changes to matched product logic in shoppinglist

### DIFF
--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -161,6 +161,12 @@ export const ShoppingList = () => {
             </Button>
           </Typography>
         </Grid>
+        <Grid item xs={12}>
+          <Typography variant="body2">
+            <strong>Disclaimer:</strong> 
+            <em>The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.</em>
+          </Typography>
+        </Grid>
         <TableContainer component={Paper}>
           <Table>
             <TableHead>

--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -37,6 +37,9 @@ const shoppingListQuery = graphql`
                 quantity
                 unit
                 productKeyword
+                substituteIngredient {
+                  name
+                }
                 matchedProducts {
                   nodes {
                     id
@@ -77,6 +80,7 @@ export const ShoppingList = () => {
     mealsById: Meal[];
     quantity: any[];
     unit: string[];
+    substituteIngredient: string;
     matchedProducts: Product[];
   }
   
@@ -100,6 +104,7 @@ export const ShoppingList = () => {
         const productKeyword = ingredient.productKeyword.toLowerCase();
         const quantity = ingredient.quantity;
         const unit = ingredient.unit;
+        const subIngredient = ingredient.substituteIngredient?.name.toLowerCase() || "";
         const matchedProducts = ingredient.matchedProducts.nodes.map(product => ({
           id: product.id,
           productName: product.nameEn, 
@@ -121,6 +126,7 @@ export const ShoppingList = () => {
               existingIngredientDetails.unit.push(unit);
               
             }
+            existingIngredientDetails.substituteIngredient = subIngredient;
             existingIngredientDetails.matchedProducts.push(
               ...matchedProducts.filter(
                 (product) => !existingIngredientDetails.matchedProducts.some(p => p.id === product.id)
@@ -134,6 +140,7 @@ export const ShoppingList = () => {
               mealsById: [{ id: mealId, name: mealName }],
               quantity: [quantity],
               unit: [unit],
+              substituteIngredient: subIngredient,
               matchedProducts: matchedProducts
             });
           }
@@ -151,7 +158,7 @@ export const ShoppingList = () => {
         </Grid>
         <Grid item xs={8}>
           <Typography variant="h4">
-            Shopping List - {mealPlan?.nameEn} &nbsp;
+            {"Shopping List - "}{mealPlan?.nameEn} &nbsp;
             <Button
               onClick={() => {
                 window.print();
@@ -162,11 +169,11 @@ export const ShoppingList = () => {
           </Typography>
         </Grid>
         <Grid item xs={12}>
-          <Typography variant="body2">
-            <em>
+          <Typography variant="body2" style={{ marginBottom: '1em' }}>
+            <div style={{ fontStyle: 'italic' }}>
               <strong>Disclaimer:</strong> 
               The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.
-            </em>
+            </div>
           </Typography>
         </Grid>
         <TableContainer component={Paper}>
@@ -182,8 +189,18 @@ export const ShoppingList = () => {
               {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails]) => (
                 <TableRow key={ingredientName}>
                   <TableCell>
-                    <Checkbox />
-                    {ingredientName}
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <Checkbox />
+                      <div>
+                        {ingredientName}
+                        {ingredientDetails.substituteIngredient !== "" &&
+                          <div style={{ fontStyle: 'italic' }}>
+                            {'Substitutes: '}
+                            {ingredientDetails.substituteIngredient}
+                          </div>
+                        }
+                      </div>
+                    </div>
                   </TableCell>
                   <TableCell>
                     {ingredientDetails.quantity.map((mealQuantities, index) => (

--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -163,8 +163,10 @@ export const ShoppingList = () => {
         </Grid>
         <Grid item xs={12}>
           <Typography variant="body2">
-            <strong>Disclaimer:</strong> 
-            <em>The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.</em>
+            <em>
+              <strong>Disclaimer:</strong> 
+              The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.
+            </em>
           </Typography>
         </Grid>
         <TableContainer component={Paper}>

--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -68,6 +68,7 @@ export const ShoppingList = () => {
   interface Meal {
     id: string;
     name: string;
+    matchedProducts: Product[]
   }
 
   interface Product {
@@ -81,7 +82,6 @@ export const ShoppingList = () => {
     quantity: any[];
     unit: string[];
     substituteIngredient: string;
-    matchedProducts: Product[];
   }
   
   const mealsByIngredient: Map<string, MealIngredient> = new Map<string, MealIngredient>();
@@ -121,27 +121,19 @@ export const ShoppingList = () => {
             const mealExists = existingIngredientDetails.mealsById.some(meal => meal.id === mealId);
 
             if (!mealExists) {
-              existingIngredientDetails.mealsById.push({ id: mealId, name: mealName });
+              existingIngredientDetails.mealsById.push({ id: mealId, name: mealName, matchedProducts: matchedProducts});
               existingIngredientDetails.quantity.push(quantity);
               existingIngredientDetails.unit.push(unit);
               
             }
             existingIngredientDetails.substituteIngredient = subIngredient;
-            existingIngredientDetails.matchedProducts.push(
-              ...matchedProducts.filter(
-                (product) => !existingIngredientDetails.matchedProducts.some(p => p.id === product.id)
-              )  
-            );
-            
-                
             mealsByIngredient.set(ingredientName, existingIngredientDetails);
           } else {
             mealsByIngredient.set(ingredientName, {
-              mealsById: [{ id: mealId, name: mealName }],
+              mealsById: [{ id: mealId, name: mealName, matchedProducts: matchedProducts }],
               quantity: [quantity],
               unit: [unit],
-              substituteIngredient: subIngredient,
-              matchedProducts: matchedProducts
+              substituteIngredient: subIngredient
             });
           }
         }
@@ -150,88 +142,95 @@ export const ShoppingList = () => {
   });
   return (
     <>
-      <Grid container spacing="5" sx={{ padding: "2rem" }}>
-        <Grid xs={12}>
-          <Typography variant="subtitle1" sx={{ mr: 5 }}>
-            {mealPlan?.person && `Prepared for ${mealPlan.person.fullName}`}
-          </Typography>
-        </Grid>
-        <Grid item xs={8}>
-          <Typography variant="h4">
-            {"Shopping List - "}{mealPlan?.nameEn} &nbsp;
-            <Button
-              onClick={() => {
-                window.print();
-              }}
-            >
-              <Print></Print>
-            </Button>
-          </Typography>
-        </Grid>
-        <Grid item xs={12}>
-          <Typography variant="body2" style={{ marginBottom: '1em' }}>
-            <div style={{ fontStyle: 'italic' }}>
-              <strong>Disclaimer:</strong> 
-              The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.
-            </div>
-          </Typography>
-        </Grid>
-        <TableContainer component={Paper}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell style={{ color: "#000" }}>Ingredient</TableCell>
-                <TableCell style={{ color: "#000" }}>Meal - Quantity/Unit</TableCell>
-                <TableCell style={{ color: "#000" }}>Suggested Product</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails]) => (
-                <TableRow key={ingredientName}>
-                  <TableCell>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <Checkbox />
-                      <div>
-                        {ingredientName}
-                        {ingredientDetails.substituteIngredient !== "" &&
-                          <div style={{ fontStyle: 'italic' }}>
-                            {'Substitutes: '}
-                            {ingredientDetails.substituteIngredient}
-                          </div>
-                        }
+      {Array.from(mealsByIngredient.entries()).length === 0 ? (
+          <h3 style={{ textAlign: "center" }}>There are no meals added to this mealplan </h3>
+      ) : (
+        <Grid container spacing="5" sx={{ padding: "2rem" }}>
+          <Grid xs={12}>
+            <Typography variant="subtitle1" sx={{ mr: 5 }}>
+              {mealPlan?.person && `Prepared for ${mealPlan.person.fullName}`}
+            </Typography>
+          </Grid>
+          <Grid item xs={8}>
+            <Typography variant="h4">
+              Shopping List - {mealPlan?.nameEn} &nbsp;
+              <Button
+                onClick={() => {
+                  window.print();
+                }}
+              >
+                <Print></Print>
+              </Button>
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
+            <Typography variant="body2" style={{ marginBottom: '1em' }}>
+              <div style={{ fontStyle: 'italic' }}>
+                <strong>Disclaimer:</strong> 
+                The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.
+              </div>
+            </Typography>
+          </Grid>
+          <TableContainer component={Paper}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell style={{ color: "#000" }}>Ingredient</TableCell>
+                  <TableCell style={{ color: "#000" }}>Meal - Quantity/Unit</TableCell>
+                  <TableCell style={{ color: "#000" }}>Suggested Product</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails]) => (
+                  <TableRow key={ingredientName}>
+                    <TableCell>
+                      <div style={{ display: 'flex', alignItems: 'center' }}>
+                        <Checkbox />
+                        <div>
+                          {ingredientName}
+                          {ingredientDetails.substituteIngredient !== "" &&
+                            <div style={{ fontStyle: 'italic' }}>
+                              Substitutes: {ingredientDetails.substituteIngredient}
+                            </div>
+                          }
+                        </div>
                       </div>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {ingredientDetails.quantity.map((mealQuantities, index) => (
-                      <div key={index}>
-                        <li>
-                          {ingredientDetails.mealsById[index].name}{' - '}
-                          {mealQuantities} {ingredientDetails.unit[index]} 
-                          {mealCounts.get(ingredientDetails.mealsById[index].id)! > 1 && ` x${mealCounts.get(ingredientDetails.mealsById[index].id)}`}
-                        </li>
-                      </div>
-                    ))}
-                  </TableCell>
-                  <TableCell>
-                    {ingredientDetails.matchedProducts.length > 0 ? (
-                      ingredientDetails.matchedProducts.map((product, index) => (
+                    </TableCell>
+                    <TableCell>
+                      {ingredientDetails.quantity.map((mealQuantities, index) => (
                         <div key={index}>
                           <li>
-                            {product.productName}{' - $'}{product.price}
+                            {ingredientDetails.mealsById[index].name} - {mealQuantities} {ingredientDetails.unit[index]} 
+                            {mealCounts.get(ingredientDetails.mealsById[index].id)! > 1 && ` x${mealCounts.get(ingredientDetails.mealsById[index].id)}`}
                           </li>
                         </div>
-                      ))
-                    ) : (
-                      <p>N/A</p>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Grid>
+                      ))}
+                    </TableCell>
+                    <TableCell>
+                      {ingredientDetails.mealsById.map((meal, index) => (
+                        meal.matchedProducts.length > 0 ? (
+                            ingredientDetails.mealsById.length === 1 ? (
+                              meal.matchedProducts.slice(0, 3).map((product, productIndex) => (
+                              <li key={productIndex}>
+                                {product.productName} - ${product.price}
+                              </li>
+                            ))
+                          ) : (
+                            <li key={index}>
+                              {meal.matchedProducts[0].productName} - ${meal.matchedProducts[0].price}
+                            </li>
+                          )
+                        ) : null
+                      ))}
+                      {ingredientDetails.mealsById.every(meal => meal.matchedProducts.length === 0) && 'N/A'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      )}
     </>
   );
 };

--- a/mealplanner-ui/src/pages/__generated__/ShoppingListQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/__generated__/ShoppingListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4752f18d7eb5968d99563ab017c942ad>>
+ * @generated SignedSource<<2e0ef71f8bf18453e48cbda643744083>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,6 +35,7 @@ export type ShoppingListQuery$data = {
                 readonly nodes: ReadonlyArray<{
                   readonly id: string;
                   readonly nameEn: string;
+                  readonly price: any;
                 }>;
               };
             }>;
@@ -164,7 +165,14 @@ v6 = {
                   "plural": true,
                   "selections": [
                     (v5/*: any*/),
-                    (v2/*: any*/)
+                    (v2/*: any*/),
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "price",
+                      "storageKey": null
+                    }
                   ],
                   "storageKey": null
                 }
@@ -299,16 +307,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c42487ea51876793539cf26f96be5205",
+    "cacheID": "130a7a96b9d719a3b7c9215c7a35955a",
     "id": null,
     "metadata": {},
     "name": "ShoppingListQuery",
     "operationKind": "query",
-    "text": "query ShoppingListQuery(\n  $rowId: BigInt!\n) {\n  mealPlan(rowId: $rowId) {\n    nameEn\n    descriptionEn\n    person {\n      fullName\n      id\n    }\n    mealPlanEntries {\n      nodes {\n        meal {\n          id\n          nameEn\n          ingredients {\n            nodes {\n              id\n              name\n              quantity\n              unit\n              productKeyword\n              matchedProducts {\n                nodes {\n                  id\n                  nameEn\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ShoppingListQuery(\n  $rowId: BigInt!\n) {\n  mealPlan(rowId: $rowId) {\n    nameEn\n    descriptionEn\n    person {\n      fullName\n      id\n    }\n    mealPlanEntries {\n      nodes {\n        meal {\n          id\n          nameEn\n          ingredients {\n            nodes {\n              id\n              name\n              quantity\n              unit\n              productKeyword\n              matchedProducts {\n                nodes {\n                  id\n                  nameEn\n                  price\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "82874f9edef57f9d05e207ff6658c152";
+(node as any).hash = "7523bcd6e3a4adc111c4a3ff1e3a307f";
 
 export default node;

--- a/mealplanner-ui/src/pages/__generated__/ShoppingListQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/__generated__/ShoppingListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2e0ef71f8bf18453e48cbda643744083>>
+ * @generated SignedSource<<8c08ff9248ce041d396d54adb2771665>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,9 @@ export type ShoppingListQuery$data = {
               readonly quantity: any;
               readonly unit: string;
               readonly productKeyword: string;
+              readonly substituteIngredient: {
+                readonly name: string;
+              } | null;
               readonly matchedProducts: {
                 readonly nodes: ReadonlyArray<{
                   readonly id: string;
@@ -96,90 +99,54 @@ v5 = {
 v6 = {
   "alias": null,
   "args": null,
-  "concreteType": "Meal",
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "quantity",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "unit",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "productKeyword",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ProductsConnection",
   "kind": "LinkedField",
-  "name": "meal",
+  "name": "matchedProducts",
   "plural": false,
   "selections": [
-    (v5/*: any*/),
-    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
-      "concreteType": "IngredientsConnection",
+      "concreteType": "Product",
       "kind": "LinkedField",
-      "name": "ingredients",
-      "plural": false,
+      "name": "nodes",
+      "plural": true,
       "selections": [
+        (v5/*: any*/),
+        (v2/*: any*/),
         {
           "alias": null,
           "args": null,
-          "concreteType": "Ingredient",
-          "kind": "LinkedField",
-          "name": "nodes",
-          "plural": true,
-          "selections": [
-            (v5/*: any*/),
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "name",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "quantity",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "unit",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "productKeyword",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "ProductsConnection",
-              "kind": "LinkedField",
-              "name": "matchedProducts",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "Product",
-                  "kind": "LinkedField",
-                  "name": "nodes",
-                  "plural": true,
-                  "selections": [
-                    (v5/*: any*/),
-                    (v2/*: any*/),
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "price",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
+          "kind": "ScalarField",
+          "name": "price",
           "storageKey": null
         }
       ],
@@ -233,7 +200,59 @@ return {
                 "name": "nodes",
                 "plural": true,
                 "selections": [
-                  (v6/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Meal",
+                    "kind": "LinkedField",
+                    "name": "meal",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "IngredientsConnection",
+                        "kind": "LinkedField",
+                        "name": "ingredients",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Ingredient",
+                            "kind": "LinkedField",
+                            "name": "nodes",
+                            "plural": true,
+                            "selections": [
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              (v7/*: any*/),
+                              (v8/*: any*/),
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Ingredient",
+                                "kind": "LinkedField",
+                                "name": "substituteIngredient",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              (v10/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
                 ],
                 "storageKey": null
               }
@@ -292,7 +311,60 @@ return {
                 "name": "nodes",
                 "plural": true,
                 "selections": [
-                  (v6/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Meal",
+                    "kind": "LinkedField",
+                    "name": "meal",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "IngredientsConnection",
+                        "kind": "LinkedField",
+                        "name": "ingredients",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Ingredient",
+                            "kind": "LinkedField",
+                            "name": "nodes",
+                            "plural": true,
+                            "selections": [
+                              (v5/*: any*/),
+                              (v6/*: any*/),
+                              (v7/*: any*/),
+                              (v8/*: any*/),
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Ingredient",
+                                "kind": "LinkedField",
+                                "name": "substituteIngredient",
+                                "plural": false,
+                                "selections": [
+                                  (v6/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              (v10/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
                   (v5/*: any*/)
                 ],
                 "storageKey": null
@@ -307,16 +379,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "130a7a96b9d719a3b7c9215c7a35955a",
+    "cacheID": "11fee9a0db6637c0fdf9e0a4dbe9ef83",
     "id": null,
     "metadata": {},
     "name": "ShoppingListQuery",
     "operationKind": "query",
-    "text": "query ShoppingListQuery(\n  $rowId: BigInt!\n) {\n  mealPlan(rowId: $rowId) {\n    nameEn\n    descriptionEn\n    person {\n      fullName\n      id\n    }\n    mealPlanEntries {\n      nodes {\n        meal {\n          id\n          nameEn\n          ingredients {\n            nodes {\n              id\n              name\n              quantity\n              unit\n              productKeyword\n              matchedProducts {\n                nodes {\n                  id\n                  nameEn\n                  price\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query ShoppingListQuery(\n  $rowId: BigInt!\n) {\n  mealPlan(rowId: $rowId) {\n    nameEn\n    descriptionEn\n    person {\n      fullName\n      id\n    }\n    mealPlanEntries {\n      nodes {\n        meal {\n          id\n          nameEn\n          ingredients {\n            nodes {\n              id\n              name\n              quantity\n              unit\n              productKeyword\n              substituteIngredient {\n                name\n                id\n              }\n              matchedProducts {\n                nodes {\n                  id\n                  nameEn\n                  price\n                }\n              }\n            }\n          }\n        }\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7523bcd6e3a4adc111c4a3ff1e3a307f";
+(node as any).hash = "4998e23e398865a7dcdfe226b64073cc";
 
 export default node;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
In Shopping list page, displayed the disclaimer text. And for each ingredient, if it has a substitute ingredient, indicated that by displaying the substitute ingredient name.  In the shopping  list table, added price to be shown along side the product name. Changed the logic of displaying the products so that if there is just one meal associated with the ingredient, display the first 3 matched products. If there are multiple meals associated with an ingredient, display one matched product for each meal.
Lastly, if a mealplan has no meals inside, display "no meals added to this mealplan" instead of shopping list empty table.

**Previous behaviour**
No disclaimer text, substitute ingredient, or product price was displayed. when a user/admin/designer clicked on the shoppinglist icon for a mealplan with no meals inside, empty shopping list table was shown, which might cause confusion. As well, there were no limit on how many products to display.

**New behaviour**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/e1246654-0ced-4ee6-a3cd-51be29aea24a)

when there are no meals in a mealplan:
![image](https://github.com/CivicTechFredericton/mealplanner/assets/60271693/95362fe4-3d98-42d4-bf10-5adee94c7e97)

**Related issues addressed by this PR**
Fixes #603 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

