### PR TITLE
631 reset password is not working

### DIFF
--- a/admin-ui/src/People/service.ts
+++ b/admin-ui/src/People/service.ts
@@ -48,13 +48,12 @@ mutation ResetPassword($personId:BigInt, $passwd:String){
 }`;
 
 export const resetPassword = async (
-    client: ApolloClient<object>,
-    personId: string, 
-    password: string
-) => {
-    const result = await client.mutate(
-        {mutation: resetPasswordMutation,
-            variables: {personId, passwd: password}
-        }
-    );
-}
+  client: ApolloClient<object>,
+  personId: string,
+  password: string
+): Promise<void> => {
+  let result = await client.mutate({
+    mutation: resetPasswordMutation,
+    variables: { personId: personId, passwd: password },
+  });
+};

--- a/backend/db_migrations/000014_reset-password.down.sql
+++ b/backend/db_migrations/000014_reset-password.down.sql
@@ -1,0 +1,5 @@
+begin;
+DROP FUNCTION IF EXISTS app.reset_password(bigint, text);
+
+REVOKE EXECUTE ON FUNCTION app.reset_password(bigint, text) FROM app_admin;
+commit;

--- a/backend/db_migrations/000014_reset-password.up.sql
+++ b/backend/db_migrations/000014_reset-password.up.sql
@@ -1,0 +1,16 @@
+begin;
+create or replace function app.reset_password(p_id bigint, passwd text) returns app.person as $$
+declare
+p app.person;
+
+begin
+  update app_private.account 
+  set password_hash=crypt(passwd, gen_salt('bf')) 
+  where person_id=p_id;
+  select * into p FROM app.person WHERE id=p_id;
+  return p;
+end;
+$$ language plpgsql security definer;
+
+grant execute on function app.reset_password(bigint, text) to app_admin;
+commit;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
I created new migration files to add a new GraphQL mutation to reset the password to the server.

**Previous behaviour**
As an Admin, when clicking on the 'Reset Password' button in the admin-ui interface, it doesn't complete the operation and returns an error in the console with the error 400.

**New behaviour**
The Admin can reset the password without errors, and is redirected to the users' page.

[Screencast from 04-12-2024 02:50:43 PM.webm](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/35b064de-adba-48b4-b61d-4a33bb6426f6)

**Related issues addressed by this PR**
fixes #631 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

