### PR TITLE
644 primary ingredient missing when there are substitutes for ingredients in a meal

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -94,11 +94,6 @@ const mealQuery = graphql`
             substituteIngredientId
             substituteIngredient {
               rowId
-              name
-              unit
-              quantity
-              substituteReason
-              substituteIngredientId
             }
           }
         }
@@ -108,7 +103,6 @@ const mealQuery = graphql`
 `;
 
 export const Meal = () => {
-  
   const params = useParams();
   const node = useLazyLoadQuery<MealQuery>(
     mealQuery,
@@ -118,28 +112,10 @@ export const Meal = () => {
   const meal = node.meal;
   const data = node.meal?.nutrition;
   const nutritionData = data
-  ? Object.entries(data).filter(([key, value]) => value !== null).map(([key, value]) => <React.Fragment>{key}: {value}<br /></React.Fragment>)
-  : 'No data';
+    ? Object.entries(data) .filter(([key, value]) => value !== null) .map(([key, value]) => ( <React.Fragment> {key}: {value} <br /> </React.Fragment>))
+    : "No data";
 
-  const arrayOfAllIngredients = meal?.ingredients?.edges
-  const arrayOfIngredientsWithoutSubstitute = meal?.ingredients?.edges.map((ingredient) => {
-    console.log(ingredient.node.substituteIngredient?.name);
-  })
-  const arrayOfSubstituteIngredientsIds = meal?.ingredients?.edges
-    ?.filter((item) => item?.node.substituteIngredientId)
-    .map((item) => item?.node.substituteIngredientId);
-
-  const arrayOfIngredientsWithoutSubstituteIngredients = meal?.ingredients?.edges?.filter(
-    (item) => !arrayOfSubstituteIngredientsIds?.includes(item.node.rowId) 
-  );
-  
-  useEffect(() => {
-    console.log(arrayOfSubstituteIngredientsIds);
-    console.log(arrayOfIngredientsWithoutSubstituteIngredients);
-    console.log(arrayOfAllIngredients);
-  }, [])
-  
-  
+  const allIngredients = meal?.ingredients?.edges.map((ingredient) => ingredient.node);
   const theme = useTheme();
   const tagStyle = {
     color: "white",
@@ -321,8 +297,7 @@ export const Meal = () => {
                 },
                 "#ingredientsTable span": {
                   fontStyle: "italic",
-
-                }
+                },
               }}
             >
               <>
@@ -335,51 +310,44 @@ export const Meal = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {arrayOfIngredientsWithoutSubstituteIngredients?.map((ingredient) => {
+                    {allIngredients?.map((ingredient) => {
                       return (
-                        <tr key={ingredient.node.rowId}>
+                        <tr key={ingredient.rowId}>
                           <td>
-                            {ingredient.node.name}
-                            {ingredient.node.substituteIngredient ? (
+                            {ingredient.substituteIngredientId === null && ingredient.name}
+                            {ingredient.substituteIngredientId && (
                               <>
-                                <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Substitute: {ingredient.node.substituteIngredient.name}
+                                  Substitute: {ingredient?.name}
                                 </span>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Reason:{" "}
-                                  {ingredient.node.substituteReason
-                                    ? ingredient.node.substituteReason
+                                  Reason:
+                                  {ingredient.substituteReason
+                                    ? ingredient.substituteReason
                                     : "Not specified"}
                                 </span>
                               </>
-                            ) : (
-                              <></>
                             )}
                           </td>
                           <td style={{ textAlign: "center", verticalAlign: "top" }}>
-                            {ingredient.node.quantity}
-                            {ingredient.node.substituteIngredient ? (
+                            {ingredient.substituteIngredientId === null && ingredient.quantity}
+                            {/* {ingredient.quantity} */}
+                            {ingredient.substituteIngredient && (
                               <>
-                                <br />
-                                <span>{ingredient.node.substituteIngredient.quantity}</span>
+                                <span>{ingredient.quantity}</span>
                                 <br />
                               </>
-                            ) : (
-                              <></>
                             )}
                           </td>
                           <td style={{ paddingLeft: "0.5rem" }}>
-                            {ingredient.node.unit}
-                            {ingredient.node.substituteIngredient ? (
+                            {ingredient.substituteIngredientId === null && ingredient.unit}
+                            {/* {ingredient.unit} */}
+                            {ingredient.substituteIngredient && (
                               <>
-                                <br />
-                                <span>{ingredient.node.substituteIngredient.unit}</span>
+                                <span>{ingredient.unit}</span>
                                 <br />
                               </>
-                            ) : (
-                              <></>
                             )}
                           </td>
                           <td></td>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -14,7 +14,7 @@ import { graphql } from "babel-plugin-relay/macro";
 import { useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import { MealQuery } from "./__generated__/MealQuery.graphql";
-import React from "react";
+import React, { useEffect } from "react";
 
 const mealQuery = graphql`
   query MealQuery($mealId: BigInt!) {
@@ -84,19 +84,22 @@ const mealQuery = graphql`
         vitK
       }
       ingredients {
-        nodes {
-          rowId
-          id
-          name
-          quantity
-          unit
-          substituteIngredientId
-          substituteReason
-          substituteIngredient {
-            id
+        edges {
+          node {
             name
+            rowId
             quantity
             unit
+            substituteReason
+            substituteIngredientId
+            substituteIngredient {
+              rowId
+              name
+              unit
+              quantity
+              substituteReason
+              substituteIngredientId
+            }
           }
         }
       }
@@ -118,13 +121,23 @@ export const Meal = () => {
   ? Object.entries(data).filter(([key, value]) => value !== null).map(([key, value]) => <React.Fragment>{key}: {value}<br /></React.Fragment>)
   : 'No data';
 
-  const arrayOfSubstituteIngredientsIds = meal?.ingredients?.nodes
-    ?.filter((item) => item?.substituteIngredientId)
-    .map((item) => item?.substituteIngredientId);
+  const arrayOfAllIngredients = meal?.ingredients?.edges
+  const arrayOfIngredientsWithoutSubstitute = meal?.ingredients?.edges.map((ingredient) => {
+    console.log(ingredient.node.substituteIngredient?.name);
+  })
+  const arrayOfSubstituteIngredientsIds = meal?.ingredients?.edges
+    ?.filter((item) => item?.node.substituteIngredientId)
+    .map((item) => item?.node.substituteIngredientId);
 
-  const arrayOfIngredientsWithoutSubstituteIngredients = meal?.ingredients?.nodes?.filter(
-    (item) => !arrayOfSubstituteIngredientsIds?.includes(item.rowId) 
+  const arrayOfIngredientsWithoutSubstituteIngredients = meal?.ingredients?.edges?.filter(
+    (item) => !arrayOfSubstituteIngredientsIds?.includes(item.node.rowId) 
   );
+  
+  useEffect(() => {
+    console.log(arrayOfSubstituteIngredientsIds);
+    console.log(arrayOfIngredientsWithoutSubstituteIngredients);
+    console.log(arrayOfAllIngredients);
+  }, [])
   
   
   const theme = useTheme();
@@ -324,20 +337,20 @@ export const Meal = () => {
                   <tbody>
                     {arrayOfIngredientsWithoutSubstituteIngredients?.map((ingredient) => {
                       return (
-                        <tr key={ingredient.id}>
+                        <tr key={ingredient.node.rowId}>
                           <td>
-                            {ingredient.name}
-                            {ingredient.substituteIngredient ? (
+                            {ingredient.node.name}
+                            {ingredient.node.substituteIngredient ? (
                               <>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Substitute: {ingredient.substituteIngredient.name}
+                                  Substitute: {ingredient.node.substituteIngredient.name}
                                 </span>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
                                   Reason:{" "}
-                                  {ingredient.substituteReason
-                                    ? ingredient.substituteReason
+                                  {ingredient.node.substituteReason
+                                    ? ingredient.node.substituteReason
                                     : "Not specified"}
                                 </span>
                               </>
@@ -346,11 +359,11 @@ export const Meal = () => {
                             )}
                           </td>
                           <td style={{ textAlign: "center", verticalAlign: "top" }}>
-                            {ingredient.quantity}
-                            {ingredient.substituteIngredient ? (
+                            {ingredient.node.quantity}
+                            {ingredient.node.substituteIngredient ? (
                               <>
                                 <br />
-                                <span>{ingredient.substituteIngredient.quantity}</span>
+                                <span>{ingredient.node.substituteIngredient.quantity}</span>
                                 <br />
                               </>
                             ) : (
@@ -358,11 +371,11 @@ export const Meal = () => {
                             )}
                           </td>
                           <td style={{ paddingLeft: "0.5rem" }}>
-                            {ingredient.unit}
-                            {ingredient.substituteIngredient ? (
+                            {ingredient.node.unit}
+                            {ingredient.node.substituteIngredient ? (
                               <>
                                 <br />
-                                <span>{ingredient.substituteIngredient.unit}</span>
+                                <span>{ingredient.node.substituteIngredient.unit}</span>
                                 <br />
                               </>
                             ) : (

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b7470015f474fc44bfa18e7be186edca>>
+ * @generated SignedSource<<d3da40c847262f2881066c113ef41ae5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,20 +80,23 @@ export type MealQuery$data = {
       readonly vitK: any | null;
     } | null;
     readonly ingredients: {
-      readonly nodes: ReadonlyArray<{
-        readonly rowId: any;
-        readonly id: string;
-        readonly name: string;
-        readonly quantity: any;
-        readonly unit: string;
-        readonly substituteIngredientId: any | null;
-        readonly substituteReason: ReadonlyArray<string | null> | null;
-        readonly substituteIngredient: {
-          readonly id: string;
+      readonly edges: ReadonlyArray<{
+        readonly node: {
           readonly name: string;
+          readonly rowId: any;
           readonly quantity: any;
           readonly unit: string;
-        } | null;
+          readonly substituteReason: ReadonlyArray<string | null> | null;
+          readonly substituteIngredientId: any | null;
+          readonly substituteIngredient: {
+            readonly rowId: any;
+            readonly name: string;
+            readonly unit: string;
+            readonly quantity: any;
+            readonly substituteReason: ReadonlyArray<string | null> | null;
+            readonly substituteIngredientId: any | null;
+          } | null;
+        };
       }>;
     };
   } | null;
@@ -556,84 +559,42 @@ v64 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 },
 v65 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "quantity",
   "storageKey": null
 },
 v66 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "quantity",
+  "name": "unit",
   "storageKey": null
 },
 v67 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "unit",
+  "name": "substituteReason",
   "storageKey": null
 },
 v68 = {
   "alias": null,
   "args": null,
-  "concreteType": "IngredientsConnection",
-  "kind": "LinkedField",
-  "name": "ingredients",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Ingredient",
-      "kind": "LinkedField",
-      "name": "nodes",
-      "plural": true,
-      "selections": [
-        (v2/*: any*/),
-        (v64/*: any*/),
-        (v65/*: any*/),
-        (v66/*: any*/),
-        (v67/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "substituteIngredientId",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "substituteReason",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "Ingredient",
-          "kind": "LinkedField",
-          "name": "substituteIngredient",
-          "plural": false,
-          "selections": [
-            (v64/*: any*/),
-            (v65/*: any*/),
-            (v66/*: any*/),
-            (v67/*: any*/)
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    }
-  ],
+  "kind": "ScalarField",
+  "name": "substituteIngredientId",
+  "storageKey": null
+},
+v69 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
   "storageKey": null
 };
 return {
@@ -724,7 +685,62 @@ return {
             ],
             "storageKey": null
           },
-          (v68/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "IngredientsConnection",
+            "kind": "LinkedField",
+            "name": "ingredients",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "IngredientsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Ingredient",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v64/*: any*/),
+                      (v2/*: any*/),
+                      (v65/*: any*/),
+                      (v66/*: any*/),
+                      (v67/*: any*/),
+                      (v68/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Ingredient",
+                        "kind": "LinkedField",
+                        "name": "substituteIngredient",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v64/*: any*/),
+                          (v66/*: any*/),
+                          (v65/*: any*/),
+                          (v67/*: any*/),
+                          (v68/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
         ],
         "storageKey": null
       }
@@ -816,28 +832,85 @@ return {
               (v61/*: any*/),
               (v62/*: any*/),
               (v63/*: any*/),
-              (v64/*: any*/)
+              (v69/*: any*/)
             ],
             "storageKey": null
           },
-          (v68/*: any*/),
-          (v64/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "IngredientsConnection",
+            "kind": "LinkedField",
+            "name": "ingredients",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "IngredientsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Ingredient",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v64/*: any*/),
+                      (v2/*: any*/),
+                      (v65/*: any*/),
+                      (v66/*: any*/),
+                      (v67/*: any*/),
+                      (v68/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Ingredient",
+                        "kind": "LinkedField",
+                        "name": "substituteIngredient",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v64/*: any*/),
+                          (v66/*: any*/),
+                          (v65/*: any*/),
+                          (v67/*: any*/),
+                          (v68/*: any*/),
+                          (v69/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v69/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v69/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "0a1b3fa71be8350bd2fed80252ef5c1a",
+    "cacheID": "316227f2ab7e7e0649eaac3f6b7615b0",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      nodes {\n        rowId\n        id\n        name\n        quantity\n        unit\n        substituteIngredientId\n        substituteReason\n        substituteIngredient {\n          id\n          name\n          quantity\n          unit\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      edges {\n        node {\n          name\n          rowId\n          quantity\n          unit\n          substituteReason\n          substituteIngredientId\n          substituteIngredient {\n            rowId\n            name\n            unit\n            quantity\n            substituteReason\n            substituteIngredientId\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "07dcf53b75070a69fa8543a4ce875aef";
+(node as any).hash = "5804719de88d56284ec51c0c1edb482c";
 
 export default node;

--- a/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/Meals/__generated__/MealQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d3da40c847262f2881066c113ef41ae5>>
+ * @generated SignedSource<<160593680c8e51397bce56ae455b2e14>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,11 +90,6 @@ export type MealQuery$data = {
           readonly substituteIngredientId: any | null;
           readonly substituteIngredient: {
             readonly rowId: any;
-            readonly name: string;
-            readonly unit: string;
-            readonly quantity: any;
-            readonly substituteReason: ReadonlyArray<string | null> | null;
-            readonly substituteIngredientId: any | null;
           } | null;
         };
       }>;
@@ -723,12 +718,7 @@ return {
                         "name": "substituteIngredient",
                         "plural": false,
                         "selections": [
-                          (v2/*: any*/),
-                          (v64/*: any*/),
-                          (v66/*: any*/),
-                          (v65/*: any*/),
-                          (v67/*: any*/),
-                          (v68/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -875,11 +865,6 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v64/*: any*/),
-                          (v66/*: any*/),
-                          (v65/*: any*/),
-                          (v67/*: any*/),
-                          (v68/*: any*/),
                           (v69/*: any*/)
                         ],
                         "storageKey": null
@@ -901,16 +886,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "316227f2ab7e7e0649eaac3f6b7615b0",
+    "cacheID": "74b1de11c7d3e0759bff40b2121e12d4",
     "id": null,
     "metadata": {},
     "name": "MealQuery",
     "operationKind": "query",
-    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      edges {\n        node {\n          name\n          rowId\n          quantity\n          unit\n          substituteReason\n          substituteIngredientId\n          substituteIngredient {\n            rowId\n            name\n            unit\n            quantity\n            substituteReason\n            substituteIngredientId\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query MealQuery(\n  $mealId: BigInt!\n) {\n  meal(rowId: $mealId) {\n    rowId\n    code\n    nameEn\n    nameFr\n    tags\n    descriptionEn\n    descriptionFr\n    categories\n    photoUrl\n    videoUrl\n    method\n    totalCost\n    servingCost\n    tips\n    servingsSize\n    servingsSizeUnit\n    prepTime\n    cookTime\n    portions\n    nutritionRating\n    nutrition {\n      calcium\n      calories\n      carbohydrate\n      carbohydratePercent\n      carbohydrateUnit\n      cholesterol\n      cholesterolPercent\n      cholesterolUnit\n      dietaryFiber\n      dietaryFiberPercent\n      dietaryFiberUnit\n      iron\n      potassium\n      protein\n      proteinPercent\n      proteinUnit\n      saturatedFat\n      saturatedFatPercent\n      saturatedFatUnit\n      servingSize\n      servingSizeText\n      servingSizeUnit\n      servingsPerContainer\n      sodium\n      sodiumPercent\n      sodiumUnit\n      totalFatPercent\n      totalFat\n      totalFatUnit\n      totalSugar\n      totalSugarPercent\n      totalSugarUnit\n      transFat\n      transFatPercent\n      transFatUnit\n      vitA\n      vitB12\n      vitB6\n      vitC\n      vitD\n      vitE\n      vitK\n      id\n    }\n    ingredients {\n      edges {\n        node {\n          name\n          rowId\n          quantity\n          unit\n          substituteReason\n          substituteIngredientId\n          substituteIngredient {\n            rowId\n            id\n          }\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5804719de88d56284ec51c0c1edb482c";
+(node as any).hash = "3d414be8b54ce77d104403951b87790e";
 
 export default node;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Fix the bug in the data displayed in the Ingredients table on the Meal page.

**Previous behaviour**
The table was being rendered with the wrong data

**New behaviour**
The table now displays the correct data from the database, as you can see in the images below.

**Meals page displaying the correct data**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/b90e9ded-33a6-44c2-9346-e5eb17afe256)

**All the ingredients for this same meal in the database**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/557d4f0a-12da-47c7-b796-0aa59fc3a31d)

**Related issues addressed by this PR**
Fixes #644 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

