### PR TITLE
625 unit is missing in the products grid in matches view

### DIFF
--- a/admin-ui/src/Match/Match.tsx
+++ b/admin-ui/src/Match/Match.tsx
@@ -28,6 +28,7 @@ const getProducts = gql`
           nameEn
           price
           quantity
+          unit
           imageUrl
           sourceUrl
           upc
@@ -230,6 +231,7 @@ export const Match = (props: CreateProps) => {
           { field: "nameEn", headerName: "Product Name", width: 500 },
           { field: "price", headerName: "Price", width: 200 },
           { field: "quantity", headerName: "Quantity", width: 200 },
+          { field: "unit", headerName: "Unit", width: 200 },
           {
             field: "imageUrl",
             headerName: "Image",


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added a new column in the match dataset to display the Unit field

**Previous behaviour**
No unit value is displayed

**New behaviour**
the new column displays the Unit field

**Demonstration**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/99518493-5def-465e-839a-a8a00ae4fa9e)


**Related issues addressed by this PR**
Fixes #625 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

