### PR TITLE
Print footer in every page #469

### DIFF
--- a/mealplanner-ui/src/layouts/Footer.tsx
+++ b/mealplanner-ui/src/layouts/Footer.tsx
@@ -1,6 +1,19 @@
 //Reference: https://github.com/mui/material-ui/blob/master/docs/data/material/getting-started/templates/sticky-footer/StickyFooter.tsx
 import { Box, Container, Typography } from "@mui/material";
 
+const hide = `
+    @media print{
+      #hide{
+        display: none !important;
+      }
+    }
+  
+  `;
+
+  const newStyle = document.createElement('style');
+  newStyle.textContent = hide;
+  document.head.appendChild(newStyle);
+
 export function Footer() {
   return (
     <Box
@@ -15,7 +28,7 @@ export function Footer() {
             : theme.palette.grey[800],
       }}
     >
-      <Container maxWidth="xl">
+      <Container maxWidth="xl" id='hide'>
         <Typography variant="body1" align="center">
           For Greener Village. By Civic Tech Fredericton.
         </Typography>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -130,6 +130,25 @@ export const Meal = () => {
     return meal?.totalCost > 0 ? meal?.totalCost + "$" : "Not available";
   };
 
+  const customValue = () => {
+    window.print()
+  }
+
+
+  const bottomelement = `
+    @media print{
+      #bottomelement{
+        display: block !important;
+      }
+    }
+  
+  `;
+
+  const newStyle = document.createElement('style');
+  newStyle.textContent = bottomelement;
+  document.head.appendChild(newStyle);
+
+
   const displayTags = () => {
     return meal!.tags?.map((tag) => (
       <span>
@@ -234,17 +253,42 @@ export const Meal = () => {
             )}
           </Grid>
 
-          <Grid item xs={9} bgcolor={theme.palette.grey[200]}>
+          <Grid item xs={9} bgcolor={theme.palette.grey[200]} style={{position:'relative', minHeight:'100vh'}}>
             <Typography variant="h3">
               {meal?.nameEn}
               <IconButton
-                onClick={() => window.print()}
-                sx={{ marginLeft: "1rem", displayPrint: "none" }}
+                onClick={customValue}
+                sx={{ marginLeft: "1rem", displayPrint: "nabc123" }}
               >
                 <Print htmlColor={`${theme.palette.primary.dark}`}></Print>
               </IconButton>
             </Typography>
-
+            <div id="bottomelement" style={{position:'fixed',
+                                    bottom:0,
+                                    width:'100%',
+                                    textAlign:'center',
+                                    padding:'10px',
+                                    display:'none'}}> 
+            
+            <Typography variant="body1" align="center">
+            For Greener Village. By Civic Tech Fredericton.
+            </Typography>
+            <Typography variant="body2" align="center">
+            If you run into issues or have any suggestions or questions, please
+            feel free to post your{" "}
+            <a
+              href="https://www.civictechfredericton.com/gmpfeedback.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+            {" "}
+            feedback
+            </a>
+            </Typography>
+            <Box display= "flex" alignItems= "center" justifyContent="center">
+            <img src="/images/CivicTechLogo.png" alt="CivicTechLogo" style={{ width: '12%', height: 'auto', marginTop: '10px' }}/>
+            </Box>
+            </div>
             <Typography variant="h4">{meal?.nameFr}</Typography>
             <Typography variant="body1">
               {meal?.categories?.map((category) => (


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
The CivicTech Logo and a small description is added on the footer every printout that the user generates for a meal on the MealPlanner app. The files modified are Meal.tsx and Footer.tsx. Footer.tsx was modified to hide the Civic Tech logo and description contained in the footer of the webpage being visible on the printed page. Meal.tsx was modified to add the Civic Tech Logo and Description to the Footer of every printed page of a meal on the MealPlanner app. Here is a screenshot of how it looks now:

<img width="766" alt="image" src="https://github.com/CivicTechFredericton/mealplanner/assets/156869108/44a8f754-ce07-4d3b-a6e4-7e1520f9e2ff">

<img width="765" alt="image" src="https://github.com/CivicTechFredericton/mealplanner/assets/156869108/0ba11ec2-1731-4c60-bcd0-3a730c9efd85">


**Previous behaviour**
Previously, the Civic Tech logo and the description was not there in the Footer of every printed page of a Meal in the MealPlanner app. 

**New behaviour**
Now, whenever a user downloads a pdf of a meal from the MealPlanner app. The Civic Tech Logo and a small description is added to the Footer of every page.

**Related issues addressed by this PR**
Fixes #469

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

