### PR TITLE
Completed Bug 668 about Primary Ingredient Substitution

### DIFF
--- a/admin-ui/src/Ingredients/IngredientCreate.tsx
+++ b/admin-ui/src/Ingredients/IngredientCreate.tsx
@@ -47,7 +47,7 @@ export const IngredientCreate = (props: CreateProps) => {
           helperText="Search keyword for a buyer"
           validate={required()}
         />
-        <ReferenceInput source="substituteIngredientId" reference="ingredients">
+        <ReferenceInput source= "mealId" reference="ingredients" filter = {{mealId : id}}>
           <AutocompleteInput
             optionText={"name"}
             fullWidth

--- a/admin-ui/src/Ingredients/IngredientEdit.tsx
+++ b/admin-ui/src/Ingredients/IngredientEdit.tsx
@@ -37,7 +37,7 @@ export const IngredientEdit = (props: EditProps) => {
           fullWidth
           helperText="Search keyword for a buyer"
         />
-        <ReferenceInput source="substituteIngredientId" reference="ingredients">
+        <ReferenceInput source= "mealId" reference="ingredients" filter = {{mealId : id}}>
           <AutocompleteInput
             optionText={"name"}
             fullWidth


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
The technical changes in this pull request includes changes to the attributes within <ReferenceInput> to allow only relevant data to be passed in as options for the textbox. 

**Previous behaviour**
Whenever an admin created a substitute ingredient and tried to add a primary ingredient's name one of the fields, the relevant options were not provided by the text box.

**New behaviour**
The relevant primary ingredients are now shown in the textbox. 

**Related issues addressed by this PR**
 Fixes #668 "

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

