### PR TITLE
fix civictech logo

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -4,22 +4,22 @@ import {
   Autocomplete,
   Box,
   IconButton,
-  TextareaAutosize,
   TextField,
+  TextareaAutosize,
   Typography,
   useTheme,
 } from "@mui/material";
+import { DatePicker } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { graphql } from "babel-plugin-relay/macro";
+import dayjs, { Dayjs } from "dayjs";
 import React, { useState } from "react";
 import { useFragment, useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
 import { updateMealPlanName } from "../../state/state";
 import { MealPlanHeaderAllUsersQuery } from "./__generated__/MealPlanHeaderAllUsersQuery.graphql";
 import { MealPlanHeader_mealPlan$key } from "./__generated__/MealPlanHeader_mealPlan.graphql";
-import { DatePicker } from "@mui/x-date-pickers";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import dayjs, { Dayjs } from "dayjs";
 
 const fragment = graphql`
   fragment MealPlanHeader_mealPlan on MealPlan {

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -11,10 +11,10 @@ import {
 } from "@mui/material";
 import { Box } from "@mui/system";
 import { graphql } from "babel-plugin-relay/macro";
+import React from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import { MealQuery } from "./__generated__/MealQuery.graphql";
-import React, { useEffect } from "react";
 
 const mealQuery = graphql`
   query MealQuery($mealId: BigInt!) {
@@ -223,10 +223,11 @@ export const Meal = () => {
         </Typography>
       </Box>
       <Container maxWidth="lg" sx={{ marginTop: "1em" }}>
-        <Grid container spacing={2} rowSpacing={4}>
+        <Grid container spacing={2} rowSpacing={4} marginTop={1}>
           <Grid
             item
             xs={3}
+            
             sx={{ textAlign: "center", displayPrint: "none" }}
             bgcolor={theme.palette.grey[200]}
           >
@@ -253,7 +254,11 @@ export const Meal = () => {
             )}
           </Grid>
 
-          <Grid item xs={9} bgcolor={theme.palette.grey[200]} style={{position:'relative', minHeight:'100vh'}}>
+          <Grid item xs={9} bgcolor={theme.palette.grey[200]} style={{position:'relative'}}  sx={{
+          // Use CSS @media rule to set min-height based on print or not
+          "@media print": {
+            minHeight: "100vh"}}
+          }>
             <Typography variant="h3">
               {meal?.nameEn}
               <IconButton


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added a media query to display the civictech logo correctly on the footer of the print page

**Previous behaviour**
After removing the space from the meal page on issue 670, noticed an overlap between the civictech logo in the footer and the meal information in the print page
![Screenshot from 2024-05-15 21-00-22](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/6a021737-e7fb-45f7-89b0-2d772bdc1f2b)

**New behaviour**
Cvictech logo displayed correctly after adding media query to adjust the spaces
![Screenshot from 2024-05-15 22-09-19](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/1d3a2405-1cab-42ea-8043-fd0a008bc9fb)


**Related issues addressed by this PR**
[469](https://github.com/CivicTechFredericton/mealplanner/issues/469)

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

