### PR TITLE
Bug 668 new change

### DIFF
--- a/admin-ui/src/Ingredients/IngredientCreate.tsx
+++ b/admin-ui/src/Ingredients/IngredientCreate.tsx
@@ -52,6 +52,7 @@ export const IngredientCreate = (props: CreateProps) => {
             optionText={"name"}
             fullWidth
             helperText="The primary ingredient name for which this ingredient is a substitute of"
+            label='Primary Ingredient'
           />
         </ReferenceInput>
         <TextInput

--- a/admin-ui/src/Ingredients/IngredientCreate.tsx
+++ b/admin-ui/src/Ingredients/IngredientCreate.tsx
@@ -52,7 +52,6 @@ export const IngredientCreate = (props: CreateProps) => {
             optionText={"name"}
             fullWidth
             helperText="The primary ingredient name for which this ingredient is a substitute of"
-            label='Primary Ingredient'
           />
         </ReferenceInput>
         <TextInput

--- a/admin-ui/src/Ingredients/IngredientEdit.tsx
+++ b/admin-ui/src/Ingredients/IngredientEdit.tsx
@@ -42,7 +42,6 @@ export const IngredientEdit = (props: EditProps) => {
             optionText={"name"}
             fullWidth
             helperText="The primary ingredient name for which this ingredient is a substitute of"
-            label='Primary Ingredient'
           />
         </ReferenceInput>
         <TextInput

--- a/admin-ui/src/Ingredients/IngredientEdit.tsx
+++ b/admin-ui/src/Ingredients/IngredientEdit.tsx
@@ -42,6 +42,7 @@ export const IngredientEdit = (props: EditProps) => {
             optionText={"name"}
             fullWidth
             helperText="The primary ingredient name for which this ingredient is a substitute of"
+            label='Primary Ingredient'
           />
         </ReferenceInput>
         <TextInput

--- a/backend/db_migrations/000007_ingredient.up.sql
+++ b/backend/db_migrations/000007_ingredient.up.sql
@@ -14,6 +14,8 @@ create table if not exists app.ingredient (
     updated_at timestamp default now() not null
 );
 
+-- changing meal_id by removing "not null" should probably allow accepting null values for Primary-Substitute Ingredient part. 
+
 comment on table app.ingredient is 'Ingredients in the recipe referred with meal_id. Specific to the recipe, not to be confused with the Product quantity and unit.';
 comment on column app.ingredient.unit is 'The measurement type to be used by the preparer, i.e. tsp, tbsp, cup, mL, etc.';
 comment on column app.ingredient.code is 'Unique code for the ingredient such 1, 2, 3, to later combine as M001-I01';

--- a/backend/db_migrations/000007_ingredient.up.sql
+++ b/backend/db_migrations/000007_ingredient.up.sql
@@ -14,7 +14,7 @@ create table if not exists app.ingredient (
     updated_at timestamp default now() not null
 );
 
--- changing meal_id by removing "not null" should probably allow accepting null values for Primary-Substitute Ingredient part. 
+
 
 comment on table app.ingredient is 'Ingredients in the recipe referred with meal_id. Specific to the recipe, not to be confused with the Product quantity and unit.';
 comment on column app.ingredient.unit is 'The measurement type to be used by the preparer, i.e. tsp, tbsp, cup, mL, etc.';

--- a/backend/db_migrations/000007_ingredient.up.sql
+++ b/backend/db_migrations/000007_ingredient.up.sql
@@ -14,8 +14,6 @@ create table if not exists app.ingredient (
     updated_at timestamp default now() not null
 );
 
-
-
 comment on table app.ingredient is 'Ingredients in the recipe referred with meal_id. Specific to the recipe, not to be confused with the Product quantity and unit.';
 comment on column app.ingredient.unit is 'The measurement type to be used by the preparer, i.e. tsp, tbsp, cup, mL, etc.';
 comment on column app.ingredient.code is 'Unique code for the ingredient such 1, 2, 3, to later combine as M001-I01';


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Fixed the name of the primary ingredient textbox from `Meal` to `Primary Ingredient`. 

**Previous behaviour**
Previously, the name of the textbox was Meal.

**New behaviour**
Now, the name is changed to `Primary Ingredient`

<img width="379" alt="image" src="https://github.com/CivicTechFredericton/mealplanner/assets/156869108/8b3f4b7b-55e4-4119-ae38-d15d8f9a2e2c">


**Related issues addressed by this PR**
Fixes #668 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

