### PR TITLE
The substitute ingredient field should have the primary ingredient field saved properly and by default blank

### DIFF
--- a/admin-ui/src/Ingredients/IngredientCreate.tsx
+++ b/admin-ui/src/Ingredients/IngredientCreate.tsx
@@ -47,7 +47,7 @@ export const IngredientCreate = (props: CreateProps) => {
           helperText="Search keyword for a buyer"
           validate={required()}
         />
-        <ReferenceInput source= "mealId" reference="ingredients" filter = {{mealId : id}}>
+        <ReferenceInput source= "substituteIngredientId" reference="ingredients" filter = {{mealId : id}}>
           <AutocompleteInput
             optionText={"name"}
             fullWidth

--- a/admin-ui/src/Ingredients/IngredientEdit.tsx
+++ b/admin-ui/src/Ingredients/IngredientEdit.tsx
@@ -12,7 +12,6 @@ import { Link, useParams } from "react-router-dom";
 
 export const IngredientEdit = (props: EditProps) => {
   const { id, ingredientId } = useParams();
-
   return (
     <Edit
       resource="ingredients"
@@ -37,7 +36,10 @@ export const IngredientEdit = (props: EditProps) => {
           fullWidth
           helperText="Search keyword for a buyer"
         />
-        <ReferenceInput source= "mealId" reference="ingredients" filter = {{mealId : id}}>
+        <ReferenceInput 
+          source= "substituteIngredientId" 
+          reference="ingredients" 
+          filter = {{mealId : id}}>
           <AutocompleteInput
             optionText={"name"}
             fullWidth


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Fixed three issues #668 Unable to create primary ingredient of a substitute ingredient
1. Default value should be empty and should be possible to save it as empty. That is primary ingredient can be null on save.
2. Whatever value is selected should be saved as the primary ingredient.
3. The field name should be Primary Ingredient and not Meal.

**Previous behaviour**
Unable to save the substitute ingredient with no primary ingredient or with a correct primary ingredient. The field name was wrongly set as Meal.

**New behaviour**
1. Default value will be empty and it is possible to save it as empty. That is primary ingredient can be null on save.
2. Whatever value is selected as the primary ingredient is saved for the substitute ingredient's primary ingredient field.
3. The field name is set to Primary Ingredient and not Meal.

**Related issues addressed by this PR**
Fixes #668 first 3 issues that I mentioned in the comment section

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes? No
- [ ] Do all of the test cases pass? yes
- [ ] Has the testing been done using the default docker-compose environment? yes
- [ ] Are documentation changes required? yes
- [ ] Does this change break or alter existing behaviour? yes

