### PR TITLE
add civic tech icon in the footer on the mealplan and shopping list p…

### DIFF
--- a/mealplanner-ui/src/layouts/Footer.tsx
+++ b/mealplanner-ui/src/layouts/Footer.tsx
@@ -15,6 +15,18 @@ const hide = `
   document.head.appendChild(newStyle);
 
 export function Footer() {
+  const bottomelement = `
+    @media print{
+      #bottomelement{
+        display: block !important;
+      }
+    }
+  
+  `;
+
+  const newStyle = document.createElement('style');
+  newStyle.textContent = bottomelement;
+  document.head.appendChild(newStyle);
   return (
     <Box
       component="footer"
@@ -48,6 +60,32 @@ export function Footer() {
           <img src="/images/CivicTechLogo.png" alt="CivicTechLogo" style={{ width: '12%', height: 'auto', marginTop: '10px' }}/>
         </Box>
       </Container>
+      <div id="bottomelement" style={{position:'fixed',
+                                    bottom:0,
+                                    width:'100%',
+                                    textAlign:'center',
+                                    padding:'10px',
+                                    display:'none'}}> 
+            
+            <Typography variant="body1" align="center">
+            For Greener Village. By Civic Tech Fredericton.
+            </Typography>
+            <Typography variant="body2" align="center">
+            If you run into issues or have any suggestions or questions, please
+            feel free to post your{" "}
+            <a
+              href="https://www.civictechfredericton.com/gmpfeedback.html"
+              target="_blank"
+              rel="noreferrer"
+            >
+            {" "}
+            feedback
+            </a>
+            </Typography>
+            <Box display= "flex" alignItems= "center" justifyContent="center">
+            <img src="/images/CivicTechLogo.png" alt="CivicTechLogo" style={{ width: '12%', height: 'auto', marginTop: '10px' }}/>
+            </Box>
+            </div>
     </Box>
   );
 }

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -134,21 +134,6 @@ export const Meal = () => {
     window.print()
   }
 
-
-  const bottomelement = `
-    @media print{
-      #bottomelement{
-        display: block !important;
-      }
-    }
-  
-  `;
-
-  const newStyle = document.createElement('style');
-  newStyle.textContent = bottomelement;
-  document.head.appendChild(newStyle);
-
-
   const displayTags = () => {
     return meal!.tags?.map((tag) => (
       <span>
@@ -254,7 +239,11 @@ export const Meal = () => {
             )}
           </Grid>
 
-          <Grid item xs={9} bgcolor={theme.palette.grey[200]} style={{position:'relative'}}>
+          <Grid item xs={9} bgcolor={theme.palette.grey[200]} style={{position:'relative'}} sx={{
+          // Use CSS @media rule to set min-height based on print or not
+          "@media print": {
+            minHeight: "100vh"}}
+          }>
             <Typography variant="h3">
               {meal?.nameEn}
               <IconButton
@@ -264,32 +253,6 @@ export const Meal = () => {
                 <Print htmlColor={`${theme.palette.primary.dark}`}></Print>
               </IconButton>
             </Typography>
-            <div id="bottomelement" style={{position:'fixed',
-                                    bottom:0,
-                                    width:'100%',
-                                    textAlign:'center',
-                                    padding:'10px',
-                                    display:'none'}}> 
-            
-            <Typography variant="body1" align="center">
-            For Greener Village. By Civic Tech Fredericton.
-            </Typography>
-            <Typography variant="body2" align="center">
-            If you run into issues or have any suggestions or questions, please
-            feel free to post your{" "}
-            <a
-              href="https://www.civictechfredericton.com/gmpfeedback.html"
-              target="_blank"
-              rel="noreferrer"
-            >
-            {" "}
-            feedback
-            </a>
-            </Typography>
-            <Box display= "flex" alignItems= "center" justifyContent="center">
-            <img src="/images/CivicTechLogo.png" alt="CivicTechLogo" style={{ width: '12%', height: 'auto', marginTop: '10px' }}/>
-            </Box>
-            </div>
             <Typography variant="h4">{meal?.nameFr}</Typography>
             <Typography variant="body1">
               {meal?.categories?.map((category) => (

--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -1,3 +1,4 @@
+import { Print } from "@mui/icons-material";
 import {
   Button,
   Checkbox,
@@ -12,11 +13,10 @@ import {
   Typography
 } from "@mui/material";
 import { graphql } from "babel-plugin-relay/macro";
+import moment from 'moment';
 import { useLazyLoadQuery } from "react-relay";
 import { useParams } from "react-router";
 import { ShoppingListQuery } from "./__generated__/ShoppingListQuery.graphql";
-import { Print } from "@mui/icons-material";
-import moment from 'moment';
 
 const shoppingListQuery = graphql`
   query ShoppingListQuery($rowId: BigInt!) {
@@ -169,6 +169,15 @@ export const ShoppingList = () => {
   });
   return (
     <>
+    <style>
+        {`
+          @media print and (orientation: portrait) {
+            .rowHeightPortrait {
+              height: 120px; /* Adjust this value as needed */
+            }
+          }
+        `}
+      </style>
       {Array.from(mealsByIngredient.entries()).length === 0 ? (
           <h3 style={{ textAlign: "center" }}>There are no meals added to this mealplan </h3>
       ) : (
@@ -213,8 +222,8 @@ export const ShoppingList = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails]) => (
-                  <TableRow key={ingredientName}>
+              {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails], index) => (
+                  <TableRow className="rowHeightPortrait" key={ingredientName}  style={((index + 1) % 6 === 0) ? { breakBefore: "always" } : {}} >
                     <TableCell>
                       <div style={{ display: 'flex', alignItems: 'center' }}>
                         <Checkbox />


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Moved the civictech logo from the meal page to the footer to be displayed in all print pages

**Related issues addressed by this PR**
#673

**Previous behaviour**
Meal plan print page and shopping print page were missing civic tech logo in the footer and in the meal page the logo wasn't displayed correctly.
![Screenshot from 2024-05-23 18-54-55](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/38b8a055-4b18-4bc2-9e00-396c543921b4)
![Screenshot from 2024-05-23 18-55-11](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/df9eb0a3-bcad-49c1-ad58-349bbb0b40ca)
![Screenshot from 2024-05-23 18-55-51](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/0648803e-a8cb-4a38-8ff6-ee5a347c74ab)


**New behaviour**
All print pages have civictech logo on the footer of every page
![Screenshot from 2024-05-23 19-00-50](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/4a38cbce-2ebf-4669-b156-8ca84ca3016b)



![Screenshot from 2024-05-23 17-33-06](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/fedadd55-5924-4dc5-bda5-bdc55870e3bc)
![Screenshot from 2024-05-23 17-33-20](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/13b98b0e-cffd-46ad-a2b6-5242e41d8aba)
![Screenshot from 2024-05-23 17-33-23](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/160a4c7e-50d2-41a3-a37f-88270f487beb)



**Related issues addressed by this PR**
List issue numbers using the "Fixes #xxx" syntax

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

