### PR TITLE
[#666] - Added role check for Meal Plan assign user dropdown

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -144,24 +144,26 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
          
             <DialogContent>
               <Grid container columns={6} spacing={2}>
-              {planType === "mealPlan" && (
-                <Grid item xs={6}>
-                  <Autocomplete
-                    options={allUsers || []}
-                    renderInput={(params) => (
-                      <TextField
-                        {...params}
-                        label="Assign user"
-                        id="user"
-                        variant="filled"
-                      />
-                    )}
-                    onChange={(e, value) => {
-                      setUserId(value?.rowId);
-                    }}
-                  ></Autocomplete>
-                </Grid>
-                )}
+							{getCurrentPerson().personRole !== "app_user"  ? (
+			  					planType === "mealPlan" && (
+                	<Grid item xs={6}>
+                  	<Autocomplete
+                    	options={allUsers || []}
+                    	renderInput={(params) => (
+                      	<TextField
+                        	{...params}
+                        	label="Assign user"
+                        	id="user"
+                        	variant="filled"
+                      	/>
+                    	)}
+                    	onChange={(e, value) => {
+                    		setUserId(value?.rowId);
+                    	}}
+                  	></Autocomplete>
+                	</Grid>
+                	)
+								) : null}
                 <Grid item xs={6}>
               {planType === "mealPlan" && (
                 <LocalizationProvider dateAdapter={AdapterDayjs}>

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -13,7 +13,7 @@ import { graphql } from "babel-plugin-relay/macro";
 import React, { useState } from "react";
 import { useFragment, useLazyLoadQuery } from "react-relay";
 import { useNavigate } from "react-router";
-import { updateMealPlanName } from "../../state/state";
+import { updateMealPlanName, getCurrentPerson } from "../../state/state";
 import { MealPlanHeaderAllUsersQuery } from "./__generated__/MealPlanHeaderAllUsersQuery.graphql";
 import { MealPlanHeader_mealPlan$key } from "./__generated__/MealPlanHeader_mealPlan.graphql";
 import { DatePicker } from "@mui/x-date-pickers";
@@ -145,7 +145,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
               </Typography>
             )}
             <Typography padding="0.75rem 1rem"></Typography>
-            {isEditUser ? (
+            {isEditUser && getCurrentPerson().personRole !== "app_user"  ? (
               <Autocomplete
                 sx={{
                   ".css-i4bv87-MuiSvgIcon-root": {
@@ -183,7 +183,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
                   />
                 )}
               ></Autocomplete>
-            ) : (
+            ) : getCurrentPerson().personRole !== "app_user" ? ( 
               <Typography
                 padding="0.75rem 0"
                 color="primary.contrastText"
@@ -202,7 +202,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
                   ? data.person.fullName
                   : "No User Assigned"}
               </Typography>
-            )}
+            ): null }
             <LocalizationProvider dateAdapter={AdapterDayjs}>
               {!data.isTemplate ? (
                 <DatePicker


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added a check for admin role or meal designer role when displaying the assign user drop down menu on the Create Meal Plan popup.

**Previous behaviour**
The drop down menu would appear for all users, despite client users not having the ability to reassign plans.

**New behaviour**
The box does not load if a normal user but loads as normal for admin and meal designer.

**Related issues addressed by this PR**
Fixes #666 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

