### PR TITLE
Updating the logic to display the ingredients in the meal page

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -316,12 +316,13 @@ export const Meal = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {allIngredients?.map((ingredient) => {
-                      const substitute = substituteIngredients?.find((sub) => sub.substituteIngredientId === ingredient.rowId)
-                      return (
-                        <tr key={ingredient.rowId}>
+                    {allIngredients?.map((ingredient, key) => {
+                      const substitute = substituteIngredients?.find((sub) => sub.substituteIngredientId === ingredient.rowId);
+                      console.log(substitute);
+                      return ingredient.substituteIngredientId === null ? (
+                        <tr key={key}>
                           <td>
-                            {ingredient.substituteIngredientId === null && ingredient.name}
+                            {ingredient.name}
                             {substitute && (
                               <>
                                 <br />
@@ -331,7 +332,7 @@ export const Meal = () => {
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
                                   Reason:{" "}
-                                  {substitute
+                                  {substitute.substituteReason
                                     ? substitute.substituteReason
                                     : "Not specified"}
                                 </span>
@@ -339,7 +340,7 @@ export const Meal = () => {
                             )}
                           </td>
                           <td style={{ textAlign: "center", verticalAlign: "top" }}>
-                            {ingredient.substituteIngredientId === null && ingredient.quantity}
+                            {ingredient.quantity}
                             {substitute && (
                               <>
                                 <br />
@@ -349,8 +350,7 @@ export const Meal = () => {
                             )}
                           </td>
                           <td style={{ paddingLeft: "0.5rem" }}>
-                            {ingredient.substituteIngredientId === null && ingredient.unit}
-                            {/* {ingredient.unit} */}
+                            {ingredient.unit}
                             {substitute && (
                               <>
                                 <br />
@@ -360,7 +360,7 @@ export const Meal = () => {
                           </td>
                           <td></td>
                         </tr>
-                      );
+                      ): <></>;
                     })}
                   </tbody>
                 </table>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -330,7 +330,7 @@ export const Meal = () => {
                                 </span>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Reason:
+                                  Reason:{" "}
                                   {substitute
                                     ? substitute.substituteReason
                                     : "Not specified"}

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -116,6 +116,7 @@ export const Meal = () => {
     : "No data";
 
   const allIngredients = meal?.ingredients?.edges.map((ingredient) => ingredient.node);
+  const substituteIngredients = allIngredients?.filter((ingredient) => ingredient.substituteIngredientId !== null);
   const theme = useTheme();
   const tagStyle = {
     color: "white",
@@ -316,20 +317,22 @@ export const Meal = () => {
                   </thead>
                   <tbody>
                     {allIngredients?.map((ingredient) => {
+                      const substitute = substituteIngredients?.find((sub) => sub.substituteIngredientId === ingredient.rowId)
                       return (
                         <tr key={ingredient.rowId}>
                           <td>
                             {ingredient.substituteIngredientId === null && ingredient.name}
-                            {ingredient.substituteIngredientId && (
+                            {substitute && (
                               <>
+                                <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Substitute: {ingredient?.name}
+                                  Substitute: {substitute.name}
                                 </span>
                                 <br />
                                 <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
                                   Reason:
-                                  {ingredient.substituteReason
-                                    ? ingredient.substituteReason
+                                  {substitute
+                                    ? substitute.substituteReason
                                     : "Not specified"}
                                 </span>
                               </>
@@ -337,10 +340,10 @@ export const Meal = () => {
                           </td>
                           <td style={{ textAlign: "center", verticalAlign: "top" }}>
                             {ingredient.substituteIngredientId === null && ingredient.quantity}
-                            {/* {ingredient.quantity} */}
-                            {ingredient.substituteIngredient && (
+                            {substitute && (
                               <>
-                                <span>{ingredient.quantity}</span>
+                                <br />
+                                <span>{substitute.quantity}</span>
                                 <br />
                               </>
                             )}
@@ -348,10 +351,10 @@ export const Meal = () => {
                           <td style={{ paddingLeft: "0.5rem" }}>
                             {ingredient.substituteIngredientId === null && ingredient.unit}
                             {/* {ingredient.unit} */}
-                            {ingredient.substituteIngredient && (
+                            {substitute && (
                               <>
-                                <span>{ingredient.unit}</span>
                                 <br />
+                                <span>{substitute.unit}</span>
                               </>
                             )}
                           </td>


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Updated the logic to display the ingredients table in the meal page

**Previous behaviour**
The ingredient table was generated correctly only if the main ingredient and the substitute ingredient were inserted in sequence in the database. If the main ingredient is the number 1 in the list, and the substitute ingredient is the number 5 from 10 items, for example, it would generate a wrong ingredient table.

**New behaviour**
A new array with substitute ingredients was created to compare with all ingredients and render the substitute items only if their rowId matched. That way, no matter the item's position in the database, it will be generated in the right sequence.

**Table with the Ingredients and substitute ingredients**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/d52929bd-ab39-4738-b981-54f6e051128c)

**Testing adding substitute ingredients in any order**
![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/b4db8ff7-0a9e-4e82-92e8-3c7f8abd1485)


**Related issues addressed by this PR**
Fixes #644 


