### PR TITLE
644 Displaying multiple substitute ingredients in the ingredients table

### DIFF
--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -117,6 +117,8 @@ export const Meal = () => {
 
   const allIngredients = meal?.ingredients?.edges.map((ingredient) => ingredient.node);
   const substituteIngredients = allIngredients?.filter((ingredient) => ingredient.substituteIngredientId !== null);
+  console.log(allIngredients);
+  console.log(substituteIngredients);
   const theme = useTheme();
   const tagStyle = {
     color: "white",
@@ -317,50 +319,61 @@ export const Meal = () => {
                   </thead>
                   <tbody>
                     {allIngredients?.map((ingredient, key) => {
-                      const substitute = substituteIngredients?.find((sub) => sub.substituteIngredientId === ingredient.rowId);
-                      console.log(substitute);
+                      const substitute = substituteIngredients?.filter((sub) => sub.substituteIngredientId === ingredient.rowId);
                       return ingredient.substituteIngredientId === null ? (
                         <tr key={key}>
                           <td>
                             {ingredient.name}
-                            {substitute && (
-                              <>
-                                <br />
-                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Substitute: {substitute.name}
-                                </span>
-                                <br />
-                                <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
-                                  Reason:{" "}
-                                  {substitute.substituteReason
-                                    ? substitute.substituteReason
-                                    : "Not specified"}
-                                </span>
-                              </>
-                            )}
+                            {substitute &&
+                              substitute.map((sub) => {
+                                return (
+                                  <>
+                                    <br />
+                                    <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                      Substitute: {sub.name}
+                                    </span>
+                                    <br />
+                                    <span style={{ fontStyle: "italic", marginLeft: "0.5rem" }}>
+                                      Reason:{" "}
+                                      {sub.substituteReason
+                                        ? sub.substituteReason
+                                        : "Not specified"}
+                                    </span>
+                                  </>
+                                );
+                              })}
                           </td>
                           <td style={{ textAlign: "center", verticalAlign: "top" }}>
                             {ingredient.quantity}
-                            {substitute && (
-                              <>
-                                <br />
-                                <span>{substitute.quantity}</span>
-                                <br />
-                              </>
-                            )}
+                            {substitute &&
+                              substitute.map((sub) => {
+                                return (
+                                  <>
+                                    <br />
+                                    <span>{sub.quantity}</span>
+                                    <br />
+                                  </>
+                                );
+                              })}
                           </td>
-                          <td style={{ paddingLeft: "0.5rem" }}>
+                          <td style={{ textAlign: "center", verticalAlign: "top" }}>
                             {ingredient.unit}
-                            {substitute && (
-                              <>
-                                <br />
-                                <span>{substitute.unit}</span>
-                              </>
-                            )}
+                            {substitute &&
+                              substitute.map((sub) => {
+                                return (
+                                  <>
+                                    <br />
+                                    <span>{sub.unit}</span>
+                                    <br />
+                                  </>
+                                );
+                              })}
                           </td>
                           <td></td>
                         </tr>
-                      ): <></>;
+                      ) : (
+                        <></>
+                      );
                     })}
                   </tbody>
                 </table>

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -117,8 +117,6 @@ export const Meal = () => {
 
   const allIngredients = meal?.ingredients?.edges.map((ingredient) => ingredient.node);
   const substituteIngredients = allIngredients?.filter((ingredient) => ingredient.substituteIngredientId !== null);
-  console.log(allIngredients);
-  console.log(substituteIngredients);
   const theme = useTheme();
   const tagStyle = {
     color: "white",
@@ -369,7 +367,6 @@ export const Meal = () => {
                                 );
                               })}
                           </td>
-                          <td></td>
                         </tr>
                       ) : (
                         <></>


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Updated the substitute ingredient to receive an array instead of a single result match. Then, I loop through this array to display the substitute ingredients for that main ingredient.

**Previous behaviour**
Only one substitute ingredient is displayed in the ingredients list, even if the main ingredient has multiple substitutes.

**New behaviour**
The ingredients table now displays all the substitute ingredients for each single main ingredient, as in the images below:

![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/64c823b6-a0b5-4547-bae2-69539fb9fce3)

![image](https://github.com/CivicTechFredericton/mealplanner/assets/37277959/191e0b0e-69d0-4bdc-ac71-aedd7d6789bf)

**Related issues addressed by this PR**
Fixes #644 
