### PR TITLE
Change in authorization for create new template for MealPlanner app u…

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/CreateMealPlan.tsx
@@ -132,11 +132,13 @@ export const CreateMealPlan = ({ connection, refetch }: { connection: string, re
               control={<Radio checked={planType === 'mealPlan'}/>}
               label="Create New Meal Plan"
             />
-            <FormControlLabel
-              value="template"
-              control={<Radio checked={planType === 'template'}/>}
-              label="Create New Template"
-            />
+            {getCurrentPerson().personRole !== "app_user" ? (
+                <FormControlLabel
+                value="template"
+                control={<Radio checked={planType === 'template'}/>}
+                label="Create New Template"
+              />
+            ) : null}
           </RadioGroup>
         </FormControl>
         </Grid>

--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -111,12 +111,14 @@ export const MealPlans = () => {
                   />
               }
             />
-            <FormControlLabel
-              value="template"
-              control={<Radio />}
-              label="Template"
-              checked={searchType === 'template'}
-            />
+            {getCurrentPerson().personRole !== "app_user" ? (
+                <FormControlLabel
+                value="template"
+                control={<Radio />}
+                label="Template"
+                checked={searchType === 'template'}
+              />
+            ) : null}
             <FormControlLabel
               value="tags"
               control={<Radio />}


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Created a condition to only allow the users who do not have the role of app_user to view the Create New Template.


**Previous behaviour**
Previously, any user of the app would be able to create a new meal plan template, a functionality to be used only by app admins or meal designers.

**New behaviour**
Now, the app allows users with only admin and meal designer roles to create a new meal template.

![EAEB398C-77B7-4021-B8A4-A8AD36B44A44](https://github.com/CivicTechFredericton/mealplanner/assets/156869108/830b59f0-0a04-44ba-a198-8f394474ae38)




**Related issues addressed by this PR**
Fixes #687 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

