### PR TITLE
Fixed-Feature-Issue-664-Tips-in-RichText-Format

### DIFF
--- a/admin-ui/src/Meals/MealForm.tsx
+++ b/admin-ui/src/Meals/MealForm.tsx
@@ -38,7 +38,7 @@ export const MealForm = () => {
       <TextInput source="servingsSizeUnit" fullWidth />
       <NumberInput source="nutritionRating" fullWidth />
       <RichTextInput source="method" fullWidth />
-      <TextInput source="tips" fullWidth />
+      <RichTextInput source="tips" fullWidth />
     </SimpleForm>
   );
 };

--- a/mealplanner-ui/src/pages/Meals/Meal.tsx
+++ b/mealplanner-ui/src/pages/Meals/Meal.tsx
@@ -389,7 +389,13 @@ export const Meal = () => {
           </Grid>
           <Grid item xs={12}>
             <Typography variant="h6">Tips</Typography>
-            <Typography variant="body1"> {meal?.tips}</Typography>
+            <Typography variant="body1"> 
+            <div
+                dangerouslySetInnerHTML={{
+                  __html: meal?.tips || "No Tips description",
+                }}
+            />
+            </Typography>
             Nutrition Details is available with the admin.
           </Grid>
         </Grid>


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added RichTextFormat for the tips section of the MealPlanner Admin UI's MealForm.tsx file.

**Previous behaviour**
Previously, the Tips section did not accept Rich Text format.

**New behaviour**
Now, the Tips section of the Admin UI edit Meal accepts the Rich Text Format.

![7652B8C1-4445-48A9-9F34-ABA02092C1B0](https://github.com/CivicTechFredericton/mealplanner/assets/156869108/90971850-d330-475d-82b9-dc1f1956cb80)


**Related issues addressed by this PR**
Fixes #664 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

