### PR TITLE
 [#687] - Added import for currentPerson on MealPlans

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlans.tsx
@@ -9,6 +9,7 @@ import {
 import { graphql } from "babel-plugin-relay/macro";
 import { Suspense, useState } from "react";
 import { useLazyLoadQuery, useRefetchableFragment } from "react-relay";
+import { getCurrentPerson } from "../../state/state";
 import { CreateMealPlan } from "./CreateMealPlan";
 import { MealPlanCard } from "./MealPlanCard";
 import { MealPlansTags, MealPlansTagsFragment } from "./MealPlansTags";


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
This adds a singular import statement to MealPlans.tsx.

**Previous behaviour**
In MealPlans.tsx, a missing import statement for currentPerson role check was missing and caused a compile error when trying to rebuild.

**New behaviour**
Import statement was added and compile error is gone, allowing for development building like normal.

**Related issues addressed by this PR**
Fixes an issue with a previous fix for #687

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

