### PR TITLE
[#672] - Added "copy" string when inserting name into duplicate meal …

### DIFF
--- a/backend/db_migrations/000019_duplicate-mealplan-name-input.down.sql
+++ b/backend/db_migrations/000019_duplicate-mealplan-name-input.down.sql
@@ -1,0 +1,2 @@
+GRANT execute on function app.duplicate_meal_plan(bigint, bigint) to app_admin, app_meal_designer;
+drop function if exists app.duplicate_meal_plan(mealplan_id bigint, p_id bigint);

--- a/backend/db_migrations/000019_duplicate-mealplan-name-input.up.sql
+++ b/backend/db_migrations/000019_duplicate-mealplan-name-input.up.sql
@@ -1,0 +1,27 @@
+comment on column app.meal_plan_entry.days is 'MONDAY: 0, TUESDAY: 1.., SUNDAY: 6';
+
+create or replace function app.duplicate_meal_plan(mealplan_id bigint, p_id bigint) returns app.meal_plan as $$
+declare
+m app.meal_plan;
+entry_ids bigint[];
+begin
+--create a duplicate meal plan with a different meal plan id and person id p_id but the same contents
+INSERT INTO app.meal_plan (name_en, name_fr, person_id, description_en, description_fr, tags)
+ SELECT name_en||' '||'copy', name_fr||' '||'copie', p_id as person_id, description_en, description_fr, tags FROM app.meal_plan WHERE id=mealplan_id
+RETURNING * INTO m;
+-- m = UPDATE app.meal_plan SET person_id=p_id WHERE id = m.id RETURNING *;
+
+--create duplicate of all meal plan entries associated with the meal_plan_id
+
+INSERT INTO app.meal_plan_entry (category, days, meal_plan_id, meal_id)
+SELECT category, days, m.id AS meal_plan_id, meal_id FROM app.meal_plan_entry 
+WHERE meal_plan_id = mealplan_id;
+
+return m;
+
+end;
+
+$$ language plpgsql;
+
+comment on function app.duplicate_meal_plan(bigint, bigint) is 'Duplicate meal plan by anyone';
+GRANT execute on function app.duplicate_meal_plan(bigint, bigint) to app_admin, app_meal_designer, app_user;

--- a/mealplanner-ui/package-lock.json
+++ b/mealplanner-ui/package-lock.json
@@ -6779,9 +6779,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -20506,9 +20506,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "requires": {
         "jake": "^10.8.5"
       }


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
This is to add the word copy into meal plan duplicates, done at the SQL level by appending copy during the duplicateMealPlan function. By using `||` this also prevents adding in "copy" to columns if there's an intentional null entry; such as if there is an english name but no french name. This adds an additional migration that replaces the previous duplicateMealPlan function.

**Previous behaviour**
Duplicate meal plans would have the same name as their source meal plan.

**New behaviour**
The word copy now appears on duplicate meal plans.

**Related issues addressed by this PR**
Adds in feature request of [#672]

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

