### PR TITLE
change the number of the items in the print shopping list

### DIFF
--- a/mealplanner-ui/src/pages/ShoppingList.tsx
+++ b/mealplanner-ui/src/pages/ShoppingList.tsx
@@ -169,15 +169,6 @@ export const ShoppingList = () => {
   });
   return (
     <>
-    <style>
-        {`
-          @media print and (orientation: portrait) {
-            .rowHeightPortrait {
-              height: 120px; /* Adjust this value as needed */
-            }
-          }
-        `}
-      </style>
       {Array.from(mealsByIngredient.entries()).length === 0 ? (
           <h3 style={{ textAlign: "center" }}>There are no meals added to this mealplan </h3>
       ) : (
@@ -207,7 +198,7 @@ export const ShoppingList = () => {
           <Grid item xs={12}>
             <Typography variant="body2" style={{ marginBottom: '1em' }}>
               <div style={{ fontStyle: 'italic' }}>
-                <strong>Disclaimer:</strong> 
+                <strong>Disclaimer:</strong>
                 The suggested products are intended to be used as reference for informational purposes only. This is not a recommendation of where to buy. Clients need to research and verify which is suitable to their needs independently. Prices are indicative as per the data procured in March 2024. The prices may vary subject to the time of purchase, store, and mode of purchase.
               </div>
             </Typography>
@@ -223,7 +214,7 @@ export const ShoppingList = () => {
               </TableHead>
               <TableBody>
               {Array.from(mealsByIngredient.entries()).map(([ingredientName, ingredientDetails], index) => (
-                  <TableRow className="rowHeightPortrait" key={ingredientName}  style={((index + 1) % 6 === 0) ? { breakBefore: "always" } : {}} >
+                  <TableRow key={ingredientName}  style={((index + 1) % 5 === 0) ? { breakBefore: "always" } : {}} >
                     <TableCell>
                       <div style={{ display: 'flex', alignItems: 'center' }}>
                         <Checkbox />


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
changed the number of item in the shopping list displayed in a single page.

**Previous behaviour**
the list wasn't displayed correctly 
![Screenshot from 2024-05-28 10-28-55](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/0ae77d0e-d241-4a8f-949c-0abe4df50349)



**New behaviour**
Each page displays 5 items from the shopping list instead of 6
![Screenshot from 2024-05-28 10-28-31](https://github.com/CivicTechFredericton/mealplanner/assets/99453690/67c2d711-bdd0-4d0c-8582-9f1e569f1c47)


**Related issues addressed by this PR**
Fixes #673

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

