### PR TITLE
[#698] - Client users auto-assigned to duplicate meal plans

### DIFF
--- a/mealplanner-ui/package-lock.json
+++ b/mealplanner-ui/package-lock.json
@@ -6779,9 +6779,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -20506,9 +20506,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "requires": {
         "jake": "^10.8.5"
       }

--- a/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
@@ -3,8 +3,8 @@ import { commitMutation } from "relay-runtime";
 import environment from "../../relay/environment";
 
 const duplicateMealPlanGQL = graphql`
-mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
-    duplicateMealPlan(input: {mealplanId: $mealPlanId}) {
+mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!, $personId: BigInt) {
+    duplicateMealPlan(input: {mealplanId: $mealPlanId, personId: $personId}) {
         mealPlanEdge @prependEdge(connections: $connections) {
             cursor
             node {
@@ -12,6 +12,7 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
               rowId
               nameEn
               nameFr
+              personId
               descriptionEn
               descriptionFr
               person {
@@ -33,12 +34,13 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
 `;
 
 
-export const duplicateMealPlan = (connection: string, id:string) => {
+export const duplicateMealPlan = (connection: string, id:string, p_id?:string) => {
     commitMutation(environment, {
       mutation: duplicateMealPlanGQL,
       variables: {
         connections: [connection],
         mealPlanId: id.toString(),
+        personId: p_id?.toString(),
       },
       onCompleted(response, errors) {
         console.log(response);

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -151,7 +151,12 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
                     aria-label="duplicate"
                     onClick={(e) => {
                       e.stopPropagation();
-                      duplicateMealPlan(connection, mealplan.rowId);
+                      if (getCurrentPerson().personRole !== "app_user"){
+                        duplicateMealPlan(connection, mealplan.rowId);
+                      } else {
+                        duplicateMealPlan(connection, mealplan.rowId, mealplan.personId)
+                      }
+                      
                     }}
                     sx={{ "& :hover": { color: theme.palette.primary.main } }}
                   >

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/MealPlansQuery.graphql.ts
@@ -20,6 +20,7 @@ export type MealPlansQuery$data = {
         readonly id: string;
         readonly rowId: any;
         readonly nameEn: string;
+        readonly personId: any | null;
         readonly descriptionEn: string | null;
         readonly isTemplate: boolean | null;
         readonly person: {


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
`personId` was added to `MealPlansQuery` and `duplciateMealPlans` methods updated to include `personId` as an optional parameter. `MealPlanCard` now has a conditional to check for role and add `personId` parameter appropriately. No migration necessary as `duplicate_meal_plan` already looks for `p_id`.

**Previous behaviour**
Meal plans would have no user assigned when duplicated. Client users could not change this.

**New behaviour**
If current user is a client then they are auto-assigned to duplicate meal plan; otherwise behaviour is same as before.

**Related issues addressed by this PR**
Fixes #698 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

