### PR TITLE
[#698] - Added personId to duplicateMealPlanGQL mutation and check for role on backend

### DIFF
--- a/backend/db_migrations/000019_personid-on-duplicate-mealplan.down.sql
+++ b/backend/db_migrations/000019_personid-on-duplicate-mealplan.down.sql
@@ -1,0 +1,27 @@
+comment on column app.meal_plan_entry.days is 'MONDAY: 0, TUESDAY: 1.., SUNDAY: 6';
+
+create or replace function app.duplicate_meal_plan(mealplan_id bigint, p_id bigint) returns app.meal_plan as $$
+declare
+m app.meal_plan;
+entry_ids bigint[];
+begin
+--create a duplicate meal plan with a different meal plan id and person id p_id but the same contents
+INSERT INTO app.meal_plan (name_en, name_fr, person_id, description_en, description_fr, tags)
+ SELECT name_en, name_fr, p_id as person_id, description_en, description_fr, tags FROM app.meal_plan WHERE id=mealplan_id
+RETURNING * INTO m;
+-- m = UPDATE app.meal_plan SET person_id=p_id WHERE id = m.id RETURNING *;
+
+--create duplicate of all meal plan entries associated with the meal_plan_id
+
+INSERT INTO app.meal_plan_entry (category, days, meal_plan_id, meal_id)
+SELECT category, days, m.id AS meal_plan_id, meal_id FROM app.meal_plan_entry 
+WHERE meal_plan_id = mealplan_id;
+
+return m;
+
+end;
+
+$$ language plpgsql;
+
+comment on function app.duplicate_meal_plan(bigint, bigint) is 'Duplicate meal plan by meal designer or admin';
+GRANT execute on function app.duplicate_meal_plan(bigint, bigint) to app_admin, app_meal_designer; 

--- a/backend/db_migrations/000019_personid-on-duplicate-mealplan.up.sql
+++ b/backend/db_migrations/000019_personid-on-duplicate-mealplan.up.sql
@@ -1,0 +1,36 @@
+comment on column app.meal_plan_entry.days is 'MONDAY: 0, TUESDAY: 1.., SUNDAY: 6';
+
+create or replace function app.duplicate_meal_plan(mealplan_id bigint, p_id bigint) returns app.meal_plan as $$
+declare
+m app.meal_plan;
+entry_ids bigint[];
+p app.person;
+begin
+p := app.current_user_person(app.current_person());
+
+--create a duplicate meal plan with a different meal plan id and person id p_id but the same contents
+IF (p.id = p_id and p.role='app_user') THEN
+ INSERT INTO app.meal_plan (name_en, name_fr, person_id, description_en, description_fr, tags)
+  SELECT name_en, name_fr, p_id as person_id, description_en, description_fr, tags FROM app.meal_plan WHERE id=mealplan_id
+ RETURNING * INTO m;
+ELSE
+ INSERT INTO app.meal_plan (name_en, name_fr, person_id, description_en, description_fr, tags)
+  SELECT name_en, name_fr, null, description_en, description_fr, tags FROM app.meal_plan WHERE id=mealplan_id
+ RETURNING * INTO m;
+END IF;
+-- m = UPDATE app.meal_plan SET person_id=p_id WHERE id = m.id RETURNING *;
+
+--create duplicate of all meal plan entries associated with the meal_plan_id
+
+INSERT INTO app.meal_plan_entry (category, days, meal_plan_id, meal_id)
+SELECT category, days, m.id AS meal_plan_id, meal_id FROM app.meal_plan_entry 
+WHERE meal_plan_id = mealplan_id;
+
+return m;
+
+end;
+
+$$ language plpgsql;
+
+comment on function app.duplicate_meal_plan(bigint, bigint) is 'Duplicate meal plan by meal designer or admin';
+GRANT execute on function app.duplicate_meal_plan(bigint, bigint) to app_admin, app_meal_designer, app_user; 

--- a/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
@@ -3,8 +3,8 @@ import { commitMutation } from "relay-runtime";
 import environment from "../../relay/environment";
 
 const duplicateMealPlanGQL = graphql`
-mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
-    duplicateMealPlan(input: {mealplanId: $mealPlanId}) {
+mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!, $personId:BigInt!) {
+    duplicateMealPlan(input: {mealplanId: $mealPlanId, personId: $personId}) {
         mealPlanEdge @prependEdge(connections: $connections) {
             cursor
             node {
@@ -12,6 +12,7 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
               rowId
               nameEn
               nameFr
+              personId
               descriptionEn
               descriptionFr
               person {
@@ -33,12 +34,13 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
 `;
 
 
-export const duplicateMealPlan = (connection: string, id:string) => {
+export const duplicateMealPlan = (connection: string, id:string, pId:string) => {
     commitMutation(environment, {
       mutation: duplicateMealPlanGQL,
       variables: {
         connections: [connection],
         mealPlanId: id.toString(),
+        personId: pId.toString(),
       },
       onCompleted(response, errors) {
         console.log(response);

--- a/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/DuplicateMealPlan.tsx
@@ -3,8 +3,8 @@ import { commitMutation } from "relay-runtime";
 import environment from "../../relay/environment";
 
 const duplicateMealPlanGQL = graphql`
-mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!, $personId: BigInt) {
-    duplicateMealPlan(input: {mealplanId: $mealPlanId, personId: $personId}) {
+mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!) {
+    duplicateMealPlan(input: {mealplanId: $mealPlanId}) {
         mealPlanEdge @prependEdge(connections: $connections) {
             cursor
             node {
@@ -12,7 +12,6 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!, $
               rowId
               nameEn
               nameFr
-              personId
               descriptionEn
               descriptionFr
               person {
@@ -34,13 +33,12 @@ mutation DuplicateMealPlanMutation($connections: [ID!]!, $mealPlanId: BigInt!, $
 `;
 
 
-export const duplicateMealPlan = (connection: string, id:string, p_id?:string) => {
+export const duplicateMealPlan = (connection: string, id:string) => {
     commitMutation(environment, {
       mutation: duplicateMealPlanGQL,
       variables: {
         connections: [connection],
         mealPlanId: id.toString(),
-        personId: p_id?.toString(),
       },
       onCompleted(response, errors) {
         console.log(response);

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -151,12 +151,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
                     aria-label="duplicate"
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (getCurrentPerson().personRole !== "app_user"){
-                        duplicateMealPlan(connection, mealplan.rowId);
-                      } else {
-                        duplicateMealPlan(connection, mealplan.rowId, mealplan.personId)
-                      }
-                      
+                      duplicateMealPlan(connection, mealplan.rowId);
                     }}
                     sx={{ "& :hover": { color: theme.palette.primary.main } }}
                   >

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanCard.tsx
@@ -151,7 +151,7 @@ export const MealPlanCard = (props: MealPlanCardProps) => {
                     aria-label="duplicate"
                     onClick={(e) => {
                       e.stopPropagation();
-                      duplicateMealPlan(connection, mealplan.rowId);
+                      duplicateMealPlan(connection, mealplan.rowId,getCurrentPerson().personID);
                     }}
                     sx={{ "& :hover": { color: theme.palette.primary.main } }}
                   >


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Adds the personId in the GQL mutation and added a role and id check in a migration when duplicating meal plans

**Previous behaviour**
Before duplicate plans wouldn't add the current person to the duplicate plans if they were a client, and as a client they can't add their name themselves.

**New behaviour**
Now persons are automatically added to the duplicate. Non-client accounts such as admin or meal designer continue to have no user assigned.

**Related issues addressed by this PR**
Fixes [#698]

**Important notes**
There is potentially a separate bug where personId is passed implicitly. This will have to be addressed at a later point.

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

