### PR TITLE
[#704] - Updated tips field in meal summary tab in admin-ui to be ric…

### DIFF
--- a/admin-ui/src/Meals/MealDetails.tsx
+++ b/admin-ui/src/Meals/MealDetails.tsx
@@ -46,7 +46,7 @@ export const Details = () => {
           <NumberField source="cookTime" />
           <NumberField source="totalCost" />
           <NumberField source="servingCost" />
-          <TextField source="tips" />
+          <RichTextField source="tips" />
           <NumberField source="servingsSize" />
           <TextField source="servingsSizeUnit" />
           <NumberField source="portions" />


### PR DESCRIPTION
…h text

**Describe the technical changes contained in this PR**
Changed the tips field in the meal summary tab in admin UI (`MealDetails.tsx`) from `TextField` to `RichTextField`. Tips could be entered as rich text but wouldn't be displayed as such in summary.

**Previous behaviour**
Tips saved with rich text would be displayed with HTML tags, for things such as ordered lists, under summary in admin-ui

**New behaviour**
Tips now display with rich text; leaving only properly displayed lists and text instead of HTML  tags.

**Related issues addressed by this PR**
Fixes #704 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

