### PR TITLE
[#700] - Added cascading delete to ingredients, meals, and matches

### DIFF
--- a/backend/db_migrations/000020_match-cascade-delete.down.sql
+++ b/backend/db_migrations/000020_match-cascade-delete.down.sql
@@ -1,0 +1,17 @@
+begin;
+alter table app.ingredient
+drop constraint ingredient_substitute_ingredient_id_fkey,
+add constraint ingredient_substitute_ingredient_id_fkey
+   foreign key (substitute_ingredient_id)
+   references app.ingredient(id),
+drop constraint ingredient_meal_id_fkey,
+add constraint ingredient_meal_id_fkey
+   foreign key (meal_id)
+   references app.meal(id);
+
+alter table app.match
+drop constraint match_ingredient_id_fkey,
+add constraint match_ingredient_id_fkey
+    foreign key (ingredient_id)
+    references app.ingredient(id);
+commit;

--- a/backend/db_migrations/000020_match-cascade-delete.up.sql
+++ b/backend/db_migrations/000020_match-cascade-delete.up.sql
@@ -1,0 +1,20 @@
+begin;
+alter table app.ingredient
+drop constraint ingredient_substitute_ingredient_id_fkey,
+add constraint ingredient_substitute_ingredient_id_fkey
+   foreign key (substitute_ingredient_id)
+   references app.ingredient(id)
+   on delete set null, --to avoid a further error of trying to delete a primary ingredient that doesn't exist, we must set the substitute to null
+drop constraint ingredient_meal_id_fkey,
+add constraint ingredient_meal_id_fkey
+   foreign key (meal_id)
+   references app.meal(id) 
+   on delete cascade;
+
+alter table app.match
+drop constraint match_ingredient_id_fkey,
+add constraint match_ingredient_id_fkey
+    foreign key (ingredient_id)
+    references app.ingredient(id)
+    on delete cascade;
+commit;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
A cascading delete was added to `ingredient_id` foreign key `in app.match` and `meal_id` foreign key in `app.ingredient`. An `on delete set null` was added to `substitute_ingredient_id` in `app.ingredient` to prevent a further error where the cascade would attempt to delete an ingredient that no longer existed.

**Previous behaviour**
Image of meal error: ![Screenshot 2024-06-05 125202](https://github.com/CivicTechFredericton/mealplanner/assets/49445122/f9d88ddc-00e1-4ec1-bf5d-541c338e465d)
Meals would show a red box error(...'violates foreign key constaint "ingredient_meal_id_fkey" on table "ingredient") in admin UI when attempting to delete meals with ingredients still associated with the meals. A similar error would be shown when attempting to delete all ingredients in a meal at once with `substitute_ingredient_id`. GraphQL would also report an error.

**New behaviour**
Previous errors no longer appear and graphql no longer reports an error.

Steps to reproduce previous behaviour:
Delete a meal
1. Go to "Admin UI", 
2. Select a meal 
3. Delete selected meal 
4. If the error doesn't show immediately, wait ~5-10 seconds

Delete multiple ingredients
1. Go to '.admin UI.'
2. Click on 'any meal'
3. Select 'Ingredients'
4. Select all ingredients (ensure all ingredients are on the same page) and click on Delete
5. If the error doesn't show immediately, wait ~5-10 seconds


**Related issues addressed by this PR**
Fixes #700 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

