### PR TITLE
Added fix for arranging meal and meal plan tags in ascending order

### DIFF
--- a/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlansTags.tsx
@@ -40,8 +40,21 @@ export const MealPlansTags = ({ tags }: { tags: MealPlansTags_tags$key }) => {
   return (
     <Grid container direction="column" margin="0rem 2rem">
       <Stack direction="row" spacing={1}>
-        {mptags.allMealPlanTags?.edges.map((edge, index) => {
-          const node = edge?.node;
+        {mptags.allMealPlanTags?.edges.map( edge => edge?.node).filter(node => node !== null && node !== undefined).sort((a,b) => {
+
+          if (a===null || b===null){
+              return 0;
+          }
+          else{
+              return a.localeCompare(b);
+          }
+          }
+
+          ).map((edge, index) => {
+
+
+
+          const node = edge;
           if (node !== null) {
             return (
             

--- a/mealplanner-ui/src/pages/Meals/MealTags.tsx
+++ b/mealplanner-ui/src/pages/Meals/MealTags.tsx
@@ -40,8 +40,18 @@ export const MealTags = ({ tags }: { tags: MealTags_tags$key }) => {
   return (
     <Grid container direction="column" margin="0rem 2rem">
       <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', width: '100%' }}>
-        {mealTags.allMealTags?.edges.map((edge, index) => {
-          const node = edge?.node;
+        {mealTags.allMealTags?.edges.map( edge => edge?.node).filter(node => node !== null && node !== undefined).sort((a,b) => {
+
+          if (a===null || b===null){
+            return 0;
+          }
+          else{
+            return a.localeCompare(b);
+          }
+        }
+        
+        ).map((edge, index) => {
+          const node = edge;
           if (node !== null && node !== undefined) {
             return (
               <Chip


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
Added fix for arranging tags in meals and mealplans in increasing order of the first letter. 

**Previous behaviour**
Previously, tags were not arranged in increasing order of the first letter. 

**New behaviour**
Now, the tags are arranged in increasing order of the first letter. 

![627CE6E7-578E-42EA-86D6-201DC4D9AA7B](https://github.com/CivicTechFredericton/mealplanner/assets/156869108/e5cc8d23-a9b7-48d7-857e-8e2bb5145bfe)


![5FAFB393-E0DC-4252-8420-60A9A503F73D](https://github.com/CivicTechFredericton/mealplanner/assets/156869108/6cff6636-43c8-4720-91e1-8702e5f981f8)




**Related issues addressed by this PR**
Fixes #707 

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?

