### PR TITLE
Meal Planner UI - Date Reset Bug Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,8 @@ In command prompt give
 ```
 direnv allow
 ```
-Then run,
 
-`bun importRecipes.ts` to import the meals and ingredients
-and
-`bun importProducts.ts` to import the products.
-
-
-
+Then, follow the instructions in the `data/README.md` file to import the data for the database tables - products, meals and ingredients.
 
 
 ## For v2

--- a/README.md
+++ b/README.md
@@ -153,12 +153,14 @@ In command prompt give
 ```
 direnv allow
 ```
-
 Then run,
 
 `bun importRecipes.ts` to import the meals and ingredients
 and
 `bun importProducts.ts` to import the products.
+
+
+
 
 
 ## For v2

--- a/README.md
+++ b/README.md
@@ -154,7 +154,11 @@ In command prompt give
 direnv allow
 ```
 
-Then, follow the instructions in the `data/README.md` file to import the data for the database tables - products, meals and ingredients.
+Then run,
+
+`bun importRecipes.ts` to import the meals and ingredients
+and
+`bun importProducts.ts` to import the products.
 
 
 ## For v2

--- a/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlanHeader.tsx
@@ -306,6 +306,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
                 descriptionEn: e.target.value,
                 personId: data.person?.rowId,
                 tags: data.tags,
+                startDate: data.startDate,
                 mealPlanName: data.nameEn,
               });
             }}
@@ -322,6 +323,7 @@ export const MealPlanHeader: React.FC<HeaderProps> = ({ mealPlan }) => {
                 descriptionEn: data.descriptionEn,
                 personId: data.person?.rowId,
                 tags: value,
+                startDate: data.startDate,
                 mealPlanName: data.nameEn,
               });
             }}


### PR DESCRIPTION
**Describe the technical changes contained in this PR**

1. In the Meal Planner UI, editing meal-plan tags or description should not alter the assigned date of the meal plan.
2. In the `README.MD` file - added reference to `data/README.md` file to import the json data from `export_recipes()` function.

**Previous behaviour**
The assigned date gets reset upon saving changes to tags or description.

**New behaviour**
The startDate field should remain unchanged, regardless of updates to tags, description, or any other fields.

**Related issues addressed by this PR**
List issue numbers using the "Fixes #723" syntax

**Video Recording**

https://github.com/user-attachments/assets/3679a5ac-715f-4963-bd7b-1c1855e356cb


**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?
