### PR TITLE
737 favorites in individual meal plan

### DIFF
--- a/backend/meal_seed.sql
+++ b/backend/meal_seed.sql
@@ -19,7 +19,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Avocado Grilled Cheese Recipe',
       'Recette de fromage grillé à lavocat',
-      '{"vegetarian", "sandwich"}',
+      '{"main_meals", "vegetarian"}',
       'The avocado sandwich is very simple yet healthy recipe',
       'Le sandwich à lavocat est une recette très simple mais saine',
       '{"Breakfast", "Snack"}',
@@ -56,7 +56,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Banana Bread',
       'Pain à la banane',
-      '{"vegetarian", "bread"}',
+      '{"desserts", "vegetarian"}',
       'The banana bread can be made with simple ingredients available at home',
       'Le pain aux bananes peut être fait avec des ingrédients simples disponibles à la maison'
       ,
@@ -96,7 +96,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Mint Chimichurri Sauce',
       'Sauce chimichurri à la menthe',
-      '{"vegan", "vegetarian", "sauce"}',
+      '{"main_meals", "vegan", "vegetarian"}',
       'The sauce can be eaten along with bread, roti or chips.',
       'La sauce peut être consommée avec du pain, du roti ou des frites',
       '{"Breakfast", "Snack", "Dinner"}',
@@ -134,7 +134,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Smashed Cucumber Salad',
       'Salade de concombre écrasé',
-      '{"vegan", "vegetarian", "salad"}',
+      '{"main_meals", "vegan", "vegetarian", "salad"}',
       'The salad is rich in nutrients and contains antioxidants',
       'La salade est riche en nutriments et contient des antioxydants',
       '{"Snack", "Dinner"}',
@@ -172,7 +172,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Mulligatawny Soup',
       'Soupe Mulligatawny',
-      '{"vegetarian", "soup", "indian cuisine"}',
+      '{"main_meals", "vegetarian", "soup"}',
       'This soup has masoor dal and coconut milk along with vegetables and spices.',
       'Cette soupe contient du masoor dal et du lait de coco, ainsi que des légumes et des épices.'
       ,
@@ -211,7 +211,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Oats Omelette',
       'Omelette à lavoine',
-      '{"vegetarian", "indian cuisine"}',
+      '{"main_meals", "vegetarian"}',
       'An easy and simple instant breakfast or snack meal with healthy rolled oats.',
       'Un petit-déjeuner ou une collation instantané facile et simple avec des flocons davoine sains.'
       ,
@@ -250,7 +250,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Pickled Red Onions',
       'oignons rouges marinés',
-      '{"vegetarian", "vegan"}',
+      '{"main_meals", "vegan", "vegetarian"}',
       'A sweet and tangy onion condiment thats perfect on sandwiches, tacos, burgers, nachos, salads, or anything that needs some extra zing!'
       ,
       'Un condiment à loignon sucré et acidulé qui est parfait sur les sandwichs, les tacos, les hamburgers, les nachos, les salades ou tout ce qui a besoin dun peu plus de piquant!'
@@ -289,7 +289,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Chana Pasta',
       'Pâtes Chana',
-      '{"vegetarian", "indian cuisine"}',
+      '{"main_meals", "vegetarian"}',
       'A spicy flavourful recipe to satisfy your hunger pangs.',
       'Une recette épicée et savoureuse pour satisfaire vos fringales.',
       '{"Snack", "Dinner"}',
@@ -327,7 +327,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Lemon Rasam / Soup',
       'Rasam Citron / Soupe',
-      '{"vegetarian", "vegan", "indian cuisine"}',
+      '{"main_meals", "vegan", "vegetarian", "soup"}',
       'A simple healthy and tasty rasam recipe that is ideally served with hot steamed rice.'
       ,
       'Une recette de rasam simple, saine et savoureuse qui est idéalement servie avec du riz chaud à la vapeur.'
@@ -367,7 +367,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Potato Masala Chips',
       'Croustilles de pomme de terre masala',
-      '{"vegetarian", "vegan", "indian cuisine"}',
+      '{"main_meals", "vegan", "vegetarian"}',
       'Potato masala chips is an instant snack prepared with potato, gram flour, rice flour, chilli powder and sesame seeds.'
       ,
       'Les chips de pomme de terre masala sont une collation instantanée préparée avec de la pomme de terre, de la farine de gramme, de la farine de riz, de la poudre de piment et des graines de sésame.'

--- a/backend/meal_seed.sql
+++ b/backend/meal_seed.sql
@@ -172,7 +172,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Mulligatawny Soup',
       'Soupe Mulligatawny',
-      '{"main_meals", "vegetarian", "soup"}',
+      '{"main_meals", "vegetarian", "soup", "indian_cuisine"}',
       'This soup has masoor dal and coconut milk along with vegetables and spices.',
       'Cette soupe contient du masoor dal et du lait de coco, ainsi que des légumes et des épices.'
       ,
@@ -211,7 +211,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Oats Omelette',
       'Omelette à lavoine',
-      '{"main_meals", "vegetarian"}',
+      '{"main_meals", "vegetarian", "indian_cuisine"}',
       'An easy and simple instant breakfast or snack meal with healthy rolled oats.',
       'Un petit-déjeuner ou une collation instantané facile et simple avec des flocons davoine sains.'
       ,
@@ -289,7 +289,7 @@ INSERT INTO app.meal
   VALUES      ( 'tcs_main',
       'Chana Pasta',
       'Pâtes Chana',
-      '{"main_meals", "vegetarian"}',
+      '{"main_meals", "vegetarian", "indian_cuisine"}',
       'A spicy flavourful recipe to satisfy your hunger pangs.',
       'Une recette épicée et savoureuse pour satisfaire vos fringales.',
       '{"Snack", "Dinner"}',
@@ -327,7 +327,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Lemon Rasam / Soup',
       'Rasam Citron / Soupe',
-      '{"main_meals", "vegan", "vegetarian", "soup"}',
+      '{"main_meals", "vegan", "vegetarian", "soup", "indian_cuisine"}',
       'A simple healthy and tasty rasam recipe that is ideally served with hot steamed rice.'
       ,
       'Une recette de rasam simple, saine et savoureuse qui est idéalement servie avec du riz chaud à la vapeur.'
@@ -367,7 +367,7 @@ INSERT INTO app.meal
   VALUES      ( 'cc_side',
       'Potato Masala Chips',
       'Croustilles de pomme de terre masala',
-      '{"main_meals", "vegan", "vegetarian"}',
+      '{"main_meals", "vegan", "vegetarian", "indian_cuisine"}',
       'Potato masala chips is an instant snack prepared with potato, gram flour, rice flour, chilli powder and sesame seeds.'
       ,
       'Les chips de pomme de terre masala sont une collation instantanée préparée avec de la pomme de terre, de la farine de gramme, de la farine de riz, de la poudre de piment et des graines de sésame.'

--- a/backend/recipes_seed.sql
+++ b/backend/recipes_seed.sql
@@ -11,7 +11,7 @@ INSERT INTO
 		            tips,
 		            servings_size, servings_size_unit, serves)
         VALUES ('c_sandwiches',
-                'Chicken Salad Sandwich',                 'Sandwich à la salade de poulet',         '{"sandwiches"}',
+                'Chicken Salad Sandwich',                 'Sandwich à la salade de poulet',         '{"main_meal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -31,7 +31,7 @@ INSERT INTO
                 0,             '',                 2),
 
                ('e_sandwiches',
-                'Egg Salad Sandwich',                     'Sandwich à la salade dœufs',             '{"sandwiches"}',
+                'Egg Salad Sandwich',                     'Sandwich à la salade dœufs',             '{"main_meal", "vegetarian", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -48,7 +48,7 @@ INSERT INTO
                 0,             '',                 3),
 
                ('mm_baked_beans',
-                'Baked Beans',                             'Haricots au lard',                       '{"main_meal", "baked_beans"}',
+                'Baked Beans',                             'Haricots au lard',                       '{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -65,7 +65,7 @@ INSERT INTO
                 0,              '',                 0),
 
                ('s_starches',
-                'Baked Potatoes',                          'Pommes de terre cuites',                 '{"sides", "starches"}',
+                'Baked Potatoes',                          'Pommes de terre cuites',                 '{"main_meal", "vegetarian", "halal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -82,7 +82,7 @@ INSERT INTO
                 0,              '',                 4),
 
                ('mm_fish',
-                'Battered Fish',                           'Poisson pané',                           '{"main_meal", "fish"}',
+                'Battered Fish',                           'Poisson pané',                           '{"main_meal", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -100,7 +100,7 @@ INSERT INTO
                 0,              '',                 4),
 
                ('mm_beef',
-                'Beef Stew',                               'Ragoût de bœuf',                         '{"main_meal", "beef"}',
+                'Beef Stew',                               'Ragoût de bœuf',                         '{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -116,7 +116,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('mm_beef_side',
-                'Beefaroni',                               'Beefaroni',                              '{"main_meal", "beef"}',
+                'Beefaroni',                               'Beefaroni',                              '{"main_meal", "nut_free"}',
                 'Macaroni, Beef and Tomato casserole',
                 'Casserole de macaronis, bœuf et tomates',
                 '{}',
@@ -130,7 +130,7 @@ INSERT INTO
                 0,              '',                 0),
 
                ('desserts',
-                'Bread And Butter Pudding',                'Pudding au pain et au beurre',           '{"desserts"}',
+                'Bread And Butter Pudding',                'Pudding au pain et au beurre',           '{"dessert", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -147,7 +147,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('breakfast',
-                'Breakfast Sandwich',                      'Sandwich déjeuner',                      '{"breakfast"}',
+                'Breakfast Sandwich',                      'Sandwich déjeuner',                      '{"main_meal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -163,7 +163,7 @@ INSERT INTO
                 0,              '',                 1),
 
                ('mm_chicken',
-                'Chicken Fajita Wraps',                    'Wraps aux fajitas au poulet',            '{"main_meal","chicken"}',
+                'Chicken Fajita Wraps',                    'Wraps aux fajitas au poulet',            '{"main_meal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -180,7 +180,7 @@ INSERT INTO
                 0,              '',                 6),
 
                ('mm_fish_side',
-                'Fish Cakes',                              'Galettes de poisson',                    '{"main_meal","fish"}',
+                'Fish Cakes',                              'Galettes de poisson',                    '{"main_meal", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -195,7 +195,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('s_starches_side',
-                'Garlic Mashed Potatoes',                  'Purée de pommes de terre à lail',        '{"sides","starches"}',
+                'Garlic Mashed Potatoes',                  'Purée de pommes de terre à lail',        '{"main_meal", "vegetarian", "halal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -209,7 +209,7 @@ INSERT INTO
                 0,              '',                 0),
 
                ('s_chowders',
-                'Hamburger Soup',                          'Soupe au hamburger',                     '{"soups","chowders"}',
+                'Hamburger Soup',                          'Soupe au hamburger',                     '{"main_meal", "nut_free", "gluten_free", "soup"}',
                 '',
                 '',
                 '{}',
@@ -223,7 +223,7 @@ INSERT INTO
                 0,              '',                 0),
 
                ('mm_pork',
-                'Roasted Herbed Pork Loin',                'Longe de porc rôtie aux herbesr',        '{"main_meals","pork"}',
+                'Roasted Herbed Pork Loin',                'Longe de porc rôtie aux herbesr',        '{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -238,7 +238,7 @@ INSERT INTO
                 0,              '',                 6),
 
                ('mm_pasta',
-                'Macaroni and Cheese',                     'Macaroni au fromage',                    '{"main_meal", "pasta"}',
+                'Macaroni and Cheese',                     'Macaroni au fromage',                    '{"main_meal", "vegetarian", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -256,7 +256,7 @@ INSERT INTO
                 0,              '',                 4),
 
                ('main_beef',
-                'Meatloaf',                                'Pain de viande',                         '{"main_meals","beef"}',
+                'Meatloaf',                                'Pain de viande',                         '{"main_meal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -272,7 +272,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('s_vegetable',
-                'Mixed Bean salad',                        'Salade de haricots mélangés',            '{"salad","vegetable"}',
+                'Mixed Bean salad',                        'Salade de haricots mélangés',            '{"salad", "vegetarian", "vegan", "halal", "nut_free", "gluten_free", "meal_accompanied"}',
                 'A simple and tasty salad, suitable to accompany almost any meal.',
                 'Une salade simple et savoureuse, adaptée pour accompagner presque tous les repas.',
                 '{}',
@@ -286,7 +286,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('mm_pork_side',
-                'Oven baked Pork Chops with an onion, mushroom sauce','Côtelettes de porc cuites au four avec un oignon, sauce aux champignons','{"main_meal", "pork"}',
+                'Oven baked Pork Chops with an onion, mushroom sauce','Côtelettes de porc cuites au four avec un oignon, sauce aux champignons','{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -304,7 +304,7 @@ INSERT INTO
                 0,              '',                 4),
 
                ('sd_starches',
-                'Rice Pilaf',                              'riz pilaf',                              '{"side_dish", "starches"}',
+                'Rice Pilaf',                              'riz pilaf',                              '{"main_meal", "vegan", "vegetarian", "halal", "nut_free", "gluten_free", "meal_accompanied"}',
                 '',
                 '',
                 '{}',
@@ -320,7 +320,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('sd_potatoes',
-                'Roasted Potatoes',                        'Pommes de terre rôties',                 '{"side_dish", "potatoes", "vegetable"}',
+                'Roasted Potatoes',                        'Pommes de terre rôties',                 '{"main_meal", "vegan", "vegetarian", "halal", "nut_free", "gluten_free", "meal_accompanied"}',
                 '',
                 '',
                 '{}',
@@ -335,7 +335,7 @@ INSERT INTO
                 0,              '',                6),
 
                ('mm_chicken_side',
-                'Sweet And Spicy Glazed Chicken Thighs',   'Cuisses De Poulet Glacées Sucrées Et Épicées', '{"main_meal", "chicken"}',
+                'Sweet And Spicy Glazed Chicken Thighs',   'Cuisses De Poulet Glacées Sucrées Et Épicées', '{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -352,7 +352,7 @@ INSERT INTO
                 0,              '',                6),
 
                ('mm_beef_mix',
-                'Beef Mix for Tacos',                      'Mélange de bœuf pour tacos',                   '{"main_meal", "beef"}',
+                'Beef Mix for Tacos',                      'Mélange de bœuf pour tacos',                   '{"main_meal", "nut_free", "gluten_free"}',
                 '',
                 '',
                 '{}',
@@ -368,7 +368,7 @@ INSERT INTO
                 0,              '',                8),
 
                ('sauce',
-                'Tartare Sauce',                           'sauce tartare',                                '{"sauce"}',
+                'Tartare Sauce',                           'sauce tartare',                                '{"halal", "nut_free", "gluten_free", "meal_accompanied"}',
                 'A classic accompaniment for battered fish',
                 'Un accompagnement classique pour le poisson pané',
                 '{}',
@@ -380,7 +380,7 @@ INSERT INTO
                 0,              '',                0),
 
                ('sauce_side',
-                'Tartare Sauce',                           'sauce tartare',                                '{"sauce"}',
+                'Tartare Sauce',                           'sauce tartare',                                '{"halal", "nut_free", "gluten_free", "meal_accompanied"}',
                 'A classic accompaniment for battered fish',
                 'Un accompagnement classique pour le poisson pané',
                 '{}',
@@ -392,7 +392,7 @@ INSERT INTO
                 0,              '',                0),
 
                ('main_fish',
-                'Tuna Noodle Casserole',                   'Casserole de nouilles au thon',                '{"main_meal", "fish"}',
+                'Tuna Noodle Casserole',                   'Casserole de nouilles au thon',                '{"main_meal", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',
@@ -409,7 +409,7 @@ INSERT INTO
                 0,              '',                6),
 
                ('salad_sandwiches',
-                'Tuna Salad Sandwich',                     'Sandwich à la salade de thon',                 '{"sandwiches"}',
+                'Tuna Salad Sandwich',                     'Sandwich à la salade de thon',                 '{"main_meal", "halal", "nut_free"}',
                 '',
                 '',
                 '{}',

--- a/backend/recipes_seed.sql
+++ b/backend/recipes_seed.sql
@@ -320,7 +320,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('sd_potatoes',
-                'Roasted Potatoes',                        'Pommes de terre rôties',                 '{"side_dish", "potatoes", "vegetables"}',
+                'Roasted Potatoes',                        'Pommes de terre rôties',                 '{"side_dish", "potatoes", "vegetable"}',
                 '',
                 '',
                 '{}',
@@ -528,7 +528,7 @@ INSERT INTO
               '{"grocery", "vegetable"}'),
              ('Carrot',             'Carotte',              'cr',     '3.47',   '3',        'lb',     '3338366002',
               'https://www.walmart.ca/en/ip/carrot-your-fresh-market/6000197111434',
-              '{"grocery", "vegetables"}'),
+              '{"grocery", "vegetable"}'),
              ('Garlic',             'Ail',                  'gl',     '0.78',   '3',        'pack',   '67929500051',
               'https://www.walmart.ca/en/ip/garlic/6000191273738',
               '{"grocery", "garlic"}'),

--- a/backend/recipes_seed.sql
+++ b/backend/recipes_seed.sql
@@ -272,7 +272,7 @@ INSERT INTO
                 0,              '',                 8),
 
                ('s_vegetable',
-                'Mixed Bean salad',                        'Salade de haricots mélangés',            '{"salad", "vegetarian", "vegan", "halal", "nut_free", "gluten_free", "meal_accompanied"}',
+                'Mixed Bean salad',                        'Salade de haricots mélangés',            '{"salad", "vegetarian", "vegan", "halal", "nut_free", "gluten_free", "main_meal"}',
                 'A simple and tasty salad, suitable to accompany almost any meal.',
                 'Une salade simple et savoureuse, adaptée pour accompagner presque tous les repas.',
                 '{}',

--- a/backend/seed.sql
+++ b/backend/seed.sql
@@ -26,7 +26,7 @@ begin;
 		cooking_duration, total_cost, serving_cost, 
 		tips, 
 		servings_size, servings_size_unit, serves) 
-        VALUES ('cc_side', 'coriander coconut chutney', 'chutney de coriandre à la noix de coco', '{"meal_accompaniment", "vegetarian", "vegan"}', 
+        VALUES ('cc_side', 'coriander coconut chutney', 'chutney de coriandre à la noix de coco', '{"meal_accompaniment", "vegetarian", "vegan", "indian_cuisine"}', 
                 'It can be used  to eat along with idli, dosa, vada, bonda or bajji', 
 		'Il peut être utilisé pour manger avec idli, dosa vada, bonda ou bajji', 
                 '{"Breakfast", "Snack", "Dinner"}', null, null, 
@@ -39,7 +39,7 @@ begin;
                 'Defreeze the coconut chunks before 30 minutes to obtain soft texture. You can grind the coconut chunks to a poweder and store it in an airtight container.',
                 2,             'tbsp',             1),
 
-               ('cs_side', 'Cucumber Dill Salad',       '', '{"meal_accompaniment", "vegetarian", "vegan", "salad"}', 
+               ('cs_side', 'Cucumber Dill Salad',       '', '{"main_meal", "vegetarian", "vegan", "salad"}', 
                 '', 
 		'', 
                 '{"Lunch", "Dinner"}', null, null, 

--- a/backend/seed.sql
+++ b/backend/seed.sql
@@ -26,7 +26,7 @@ begin;
 		cooking_duration, total_cost, serving_cost, 
 		tips, 
 		servings_size, servings_size_unit, serves) 
-        VALUES ('cc_side', 'coriander coconut chutney', 'chutney de coriandre à la noix de coco', '{"side dish", "vegetarian", "vegan", "indian cuisine"}', 
+        VALUES ('cc_side', 'coriander coconut chutney', 'chutney de coriandre à la noix de coco', '{"meal_accompaniment", "vegetarian", "vegan"}', 
                 'It can be used  to eat along with idli, dosa, vada, bonda or bajji', 
 		'Il peut être utilisé pour manger avec idli, dosa vada, bonda ou bajji', 
                 '{"Breakfast", "Snack", "Dinner"}', null, null, 
@@ -39,7 +39,7 @@ begin;
                 'Defreeze the coconut chunks before 30 minutes to obtain soft texture. You can grind the coconut chunks to a poweder and store it in an airtight container.',
                 2,             'tbsp',             1),
 
-               ('cs_side', 'Cucumber Dill Salad',       '', '{"side dish", "vegetarian", "vegan", "salad"}', 
+               ('cs_side', 'Cucumber Dill Salad',       '', '{"meal_accompaniment", "vegetarian", "vegan", "salad"}', 
                 '', 
 		'', 
                 '{"Lunch", "Dinner"}', null, null, 
@@ -52,7 +52,7 @@ begin;
                 'Defreeze the coconut chunks before 30 minutes to obtain soft texture. You can grind the coconut chunks to a poweder and store it in an airtight container.',
                 0,             '??',             8),
 
-               ('bb_brkf', 'Breakfast Burrito',         '', '{"breakfast", "lunch", "school"}', 
+               ('bb_brkf', 'Breakfast Burrito',         '', '{"breakfast", "main_meal"}', 
                 '', 
 		'', 
                 '{"Lunch", "Breakfast"}', null, null, 
@@ -65,7 +65,7 @@ begin;
                 'If for school lunch, wrap in parchment paper and refrigerate for reheating in a microwave. Or, if for a later daily meal, wrap in foil and reheat in a 325-f oven for 8 – 10 minutes.',
                 0,             '??',             6),
 
-               ('mc_main', 'Macaroni and Cheese',       '', '{"dinner", "pasta", "stovetop"}', 
+               ('mc_main', 'Macaroni and Cheese',       '', '{"main_meal", "vegetarian"}', 
                 '', 
 		'', 
                 '{"Lunch", "Dinner"}', null, null, 

--- a/data/meals-ingredients-substitutes.json
+++ b/data/meals-ingredients-substitutes.json
@@ -1362,7 +1362,7 @@
   {
     "name_en": "Sweet and Sour Sauce",
     "name_fr": null,
-    "tags": ["Sweet and Sour Sauce"],
+    "tags": [],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3410,7 +3410,7 @@
   {
     "name_en": "Trail Mix Bars",
     "name_fr": null,
-    "tags": ["Trail Mix Bars"],
+    "tags": [],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3915,7 +3915,7 @@
   {
     "name_en": "Pickled Red Onions",
     "name_fr": null,
-    "tags": ["Pickled Red Onions"],
+    "tags": [],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4369,7 +4369,7 @@
   {
     "name_en": "Quick and Easy Fish Stew",
     "name_fr": null,
-    "tags": ["Main Meals", "Fish Stew"],
+    "tags": ["Main Meals"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5423,7 +5423,7 @@
   {
     "name_en": "Skillet Cornbread",
     "name_fr": null,
-    "tags": ["Skillet Cornbread"],
+    "tags": [],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5989,7 +5989,7 @@
   {
     "name_en": "Glazed Carrots",
     "name_fr": null,
-    "tags": ["Side Dish", "Vegetables"],
+    "tags": ["Side Dish", "Vegetable"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9510,7 +9510,7 @@
   {
     "name_en": "Beef Stew",
     "name_fr": null,
-    "tags": ["Beef Stew"],
+    "tags": [],
     "description_en": null,
     "description_fr": null,
     "categories": null,

--- a/data/meals-ingredients-substitutes.json
+++ b/data/meals-ingredients-substitutes.json
@@ -2,7 +2,7 @@
   {
     "name_en": "Tuna Noodle Casserole",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Egg-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -131,7 +131,7 @@
   {
     "name_en": "Chicken Curry",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -260,7 +260,7 @@
   {
     "name_en": "Tuna Salad Sandwich",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Egg-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -317,7 +317,7 @@
   {
     "name_en": "Beef Mix for Tacos",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -430,7 +430,7 @@
   {
     "name_en": "Chicken Fricot",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied", "Soup"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -543,7 +543,7 @@
   {
     "name_en": "Herbed Yogurt Dip",
     "name_fr": null,
-    "tags": ["Snack"],
+    "tags": ["Egg-free", "Nut-free", "Vegetarian", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -635,7 +635,7 @@
   {
     "name_en": "Chicken Noodle Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Soup"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -755,7 +755,7 @@
   {
     "name_en": "Sloppy Joes",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -869,7 +869,7 @@
   {
     "name_en": "Tourtiere",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -968,7 +968,7 @@
   {
     "name_en": "Chicken Baked in Mushroom Sauce",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1060,7 +1060,7 @@
   {
     "name_en": "Baked Fish Fillets",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1146,7 +1146,7 @@
   {
     "name_en": "Risotto",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1255,7 +1255,7 @@
   {
     "name_en": "Breakfast Burrito",
     "name_fr": null,
-    "tags": ["Breakfast", "Burrito"],
+    "tags": ["Breakfast", "Meal Accompanied", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1362,7 +1362,7 @@
   {
     "name_en": "Sweet and Sour Sauce",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Vegetarian", "Vegan", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1440,7 +1440,7 @@
   {
     "name_en": "Ratatouille",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1568,7 +1568,7 @@
   {
     "name_en": "Classic Meatloaf",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Meal Accompanied", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1688,7 +1688,7 @@
   {
     "name_en": "Green Lentils with Garlic and Onions",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1766,7 +1766,7 @@
   {
     "name_en": "Oven Baked French Onion Pork Chops",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Meal Accompanied", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1844,7 +1844,7 @@
   {
     "name_en": "Fruit Salsa",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Vegan", "Vegetarian", "Halal", "Nut-free", "Gluten-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1930,7 +1930,7 @@
   {
     "name_en": "Fresh Pasta",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -1988,7 +1988,7 @@
   {
     "name_en": "Potato and Onion Soup",
     "name_fr": null,
-    "tags": ["Main Meals", "Soup"],
+    "tags": ["Main Meals", "Soup", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2123,7 +2123,7 @@
   {
     "name_en": "Balsamic Vinaigrette Dressing",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Vegan", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2194,7 +2194,7 @@
   {
     "name_en": "Vegetable Meatballs",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2295,7 +2295,7 @@
   {
     "name_en": "Onion Fritters",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2373,7 +2373,7 @@
   {
     "name_en": "Gnocchi (Potato Pasta)",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2416,7 +2416,7 @@
   {
     "name_en": "Couscous with Green Peas and Mint",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2524,7 +2524,7 @@
   {
     "name_en": "Cheddar Corn Muffins",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Vegetarian", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2616,7 +2616,7 @@
   {
     "name_en": "Vegan Mushroom Cassoulet",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2757,7 +2757,7 @@
   {
     "name_en": "O'Brien Potatoes",
     "name_fr": null,
-    "tags": ["Breakfast"],
+    "tags": ["Breakfast", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2828,7 +2828,7 @@
   {
     "name_en": "Fresh Green Pea Soup with Mint",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Soup", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2934,7 +2934,7 @@
   {
     "name_en": "Colcannon",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -2998,7 +2998,7 @@
   {
     "name_en": "Red Beans and Rice",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3097,7 +3097,7 @@
   {
     "name_en": "Smoky White Bean Shakshuka",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3226,7 +3226,7 @@
   {
     "name_en": "Banana Fritters",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Dessert", "Vegetarian", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3311,7 +3311,7 @@
   {
     "name_en": "Honey Roasted Root Vegetables",
     "name_fr": null,
-    "tags": ["Main Meals", "Vegetable"],
+    "tags": ["Main Meals", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3410,7 +3410,7 @@
   {
     "name_en": "Trail Mix Bars",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Vegetarian", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3504,7 +3504,7 @@
   {
     "name_en": "Savoury Vegan Succotash",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3617,7 +3617,7 @@
   {
     "name_en": "Spanish Rice",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3626,7 +3626,7 @@
     "method": "<ol>\n<li>In a heavy saucepan or Dutch oven, heat the oil. Add the rice and stir to coat with the oil. Cook until the rice is translucent.</li>\n<li>Add the remaining ingredients and mix well.</li>\n<li>Bring to the boil. Lower heat to low. Cover the pot and cook for about 20 minutes. Remove from the heat and let rest covered for an additional 5 -- 8 minutes.</li>\n<li>Remove the lid and fluff the rice with a fork. Taste for seasoning and add a little salt and pepper if required.</li>\n</ol>\n",
     "total_cost": null,
     "serving_cost": null,
-    "tips": "An excellent accompaniment to Tex-Mex wraps or tacos. Add some buttered sweet corn kernels for a complete meal. For Tex - Mex wraps, place some of the rice in the centre of a 12\" tortilla wrap. Add some grilled chicken and green or red pepper pieces (leftover chicken works well) and some sweet corn. Roll the tortilla, folding in the edges and heat for a few minutes in the oven or in a lightly greased frying pan.",
+    "tips": "An excellent Accompanied to Tex-Mex wraps or tacos. Add some buttered sweet corn kernels for a complete meal. For Tex - Mex wraps, place some of the rice in the centre of a 12\" tortilla wrap. Add some grilled chicken and green or red pepper pieces (leftover chicken works well) and some sweet corn. Roll the tortilla, folding in the edges and heat for a few minutes in the oven or in a lightly greased frying pan.",
     "servings_size": null,
     "servings_size_unit": null,
     "nutrition_rating": 10,
@@ -3695,7 +3695,7 @@
   {
     "name_en": "Stuffed Peppers",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3794,7 +3794,7 @@
   {
     "name_en": "Chicken Salad Sandwich",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3858,7 +3858,7 @@
   {
     "name_en": "Roasted Potatoes",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Meal Accompanied", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3915,7 +3915,7 @@
   {
     "name_en": "Pickled Red Onions",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Meal Accompanied", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -3986,7 +3986,7 @@
   {
     "name_en": "Strawberry Salsa",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Meal Accompanied", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4050,7 +4050,7 @@
   {
     "name_en": "Simple Spring Mix Salad Vinaigrette",
     "name_fr": null,
-    "tags": ["Main Meals", "Salad"],
+    "tags": ["Salad", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4121,7 +4121,7 @@
   {
     "name_en": "Jambalaya",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4241,7 +4241,7 @@
   {
     "name_en": "Cucumber Dill Salad",
     "name_fr": null,
-    "tags": ["Meal Accompaniment"],
+    "tags": ["Meal Accompanied", "Salad", "Egg-free", "Vegan", "Nut-free", "Halal", "Gluten-free", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4319,7 +4319,7 @@
   {
     "name_en": "Gnocchi (Potato pasta)",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4369,7 +4369,7 @@
   {
     "name_en": "Quick and Easy Fish Stew",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4511,7 +4511,7 @@
   {
     "name_en": "Egg Salad sandwich",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4568,7 +4568,7 @@
   {
     "name_en": "Chili",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4653,7 +4653,7 @@
   {
     "name_en": "Marinara Sauce",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Halal", "Vegetarian", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4745,7 +4745,7 @@
   {
     "name_en": "White Bean and Roasted Mushroom Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Soup", "Vegan", "Halal", "Vegetarian", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4853,7 +4853,7 @@
   {
     "name_en": "Stir Fried Cabbage",
     "name_fr": null,
-    "tags": ["Stir Fried", "Chinese"],
+    "tags": ["Main Meals", "Vegan", "Halal", "Vegetarian", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4862,7 +4862,7 @@
     "method": "<ol>\n<li>Cut the core from the cabbage and shred the leaves finely.</li>\n<li>Heat the oil in a wok or frying pan until hot and stir fry the cabbage for 2 -- 3 minutes. Add the soy sauce, lemon juice, if using, caraway seeds and pepper. Stir and toss together for 1 -- 2 minutes. Serve immediately.</li>\n</ol>\n",
     "total_cost": null,
     "serving_cost": null,
-    "tips": "An excellent accompaniment to roasted meats or a Chinese style main dish.",
+    "tips": "An excellent Accompanied to roasted meats or a Chinese style main dish.",
     "servings_size": null,
     "servings_size_unit": null,
     "nutrition_rating": 10,
@@ -4917,7 +4917,7 @@
   {
     "name_en": "Easy 6 Ingredient Chili",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4995,7 +4995,7 @@
   {
     "name_en": "Cauliflower Breadsticks",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5093,9 +5093,9 @@
     ]
   },
   {
-    "name_en": "Gluten Free Lemon Bread",
+    "name_en": "Gluten-free Lemon Bread",
     "name_fr": null,
-    "tags": ["Easy", "Gluten Free", "Lemon", "Bread"],
+    "tags": ["Dessert", "Gluten-free", "Egg-free", "Nut-free", "Halal", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5187,7 +5187,7 @@
   {
     "name_en": "Banana bread",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Vegetarian", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5266,7 +5266,7 @@
   {
     "name_en": "Green Bean Casserole",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5316,7 +5316,7 @@
   {
     "name_en": "Thai Style Sweet Potato Soup",
     "name_fr": null,
-    "tags": ["Main Meals", "Soup"],
+    "tags": ["Main Meals", "Soup", "Vegan", "Halal", "Vegetarian", "Nut-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5423,7 +5423,7 @@
   {
     "name_en": "Skillet Cornbread",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5432,7 +5432,7 @@
     "method": "<ol>\n<li>In a frying pan, fry bacon pieces until crisp. Remove the bacon from the pan and set aside. Drain the fat reserving 1 Tbsp / 15ml. <em>(this dish is best prepared and cooked in a 10&quot; cast iron skillet but can be made in an ovenproof frying pan or baking dish)</em> 2. In a bowl, stir together the cornmeal, sifted flour, baking powder and soda and salt. Mix together. Add the buttermilk or milk, the eggs and mix lightly. Add the corn, reserved bacon pieces and the melted butter or margarine. 3. Pour batter into the warm skillet, frying pan or baking dish and bake at 400f for about 20 minutes until the edges and top are lightly browned.  Serve warm</li>\n</ol>\n",
     "total_cost": null,
     "serving_cost": null,
-    "tips": "For a little added \"zip\" add a seeded chopped jalapeno pepper to the mix and bake as above. This cornbread is a great accompaniment to summer barbequed ribs, chicken or steak. Cook in a closed barbeque over medium to high heat.",
+    "tips": "For a little added \"zip\" add a seeded chopped jalapeno pepper to the mix and bake as above. This cornbread is a great Accompanied to summer barbequed ribs, chicken or steak. Cook in a closed barbeque over medium to high heat.",
     "servings_size": null,
     "servings_size_unit": null,
     "nutrition_rating": 10,
@@ -5522,7 +5522,7 @@
   {
     "name_en": "Mixed Bean Salad",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Salad", "Vegetarian", "Vegan", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5628,7 +5628,7 @@
   {
     "name_en": "Chicken Parmesan",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5783,7 +5783,7 @@
   {
     "name_en": "Roasted Vegetable Frittata",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Gluten-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5890,7 +5890,7 @@
   {
     "name_en": "Baked Beans",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -5989,7 +5989,7 @@
   {
     "name_en": "Glazed Carrots",
     "name_fr": null,
-    "tags": ["Side Dish", "Vegetable"],
+    "tags": ["Meal Accompanied", "Vegetarian", "Vegan", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6047,7 +6047,7 @@
   {
     "name_en": "White Turkey Chili",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Gluten-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6160,7 +6160,7 @@
   {
     "name_en": "Coffee Cake Muffins",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Vegetarian", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6259,7 +6259,7 @@
   {
     "name_en": "Macaroni and Cheese",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6473,7 +6473,7 @@
   {
     "name_en": "Croutons",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Meal Accompanied", "Vegetarian", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6517,7 +6517,7 @@
   {
     "name_en": "Calypso Pork Loin",
     "name_fr": null,
-    "tags": null,
+    "tags": ["Main Meals"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6766,7 +6766,7 @@
   {
     "name_en": "Pork and Cabbage Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Soup"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6865,7 +6865,7 @@
   {
     "name_en": "No-Churn Vanilla Ice Cream",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Egg-free", "Vegetarian", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -6915,7 +6915,7 @@
   {
     "name_en": "Garlic Mashed Potatoes",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Meal Accompanied"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7158,7 +7158,7 @@
   {
     "name_en": "Peanut Butter Cookies",
     "name_fr": null,
-    "tags": ["Sweet", "Cookie"],
+    "tags": ["Dessert"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7243,7 +7243,7 @@
   {
     "name_en": "Channa -- spicy chickpeas",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7252,7 +7252,7 @@
     "method": "<ol>\n<li><p>Heat the oil or ghee in a saucepan or skillet and fry the onions\nover medium heat until lightly golden brown</p>\n</li>\n<li><p>Add the remainder of the ingredients, except the fresh coriander,\nsliced onions and diced tomato and stir over medium heat until all\nthe flavours have blended and the liquid has taken on a rich brown\ncolour. Add some water if necessary.</p>\n</li>\n<li><p>Place mixture in a serving dish and sprinkle with the coriander,\ndiced tomato and onion rings. Serve warm or cold.</p>\n</li>\n</ol>\n",
     "total_cost": null,
     "serving_cost": null,
-    "tips": "A wonderful, easy to prepare dish, that can be eaten as a snack, a side dish with a meal or as an accompaniment to rice. In many parts of the world it is served by street vendors in paper cones.",
+    "tips": "A wonderful, easy to prepare dish, that can be eaten as a snack, a side dish with a meal or as an Accompanied to rice. In many parts of the world it is served by street vendors in paper cones.",
     "servings_size": null,
     "servings_size_unit": null,
     "nutrition_rating": 10,
@@ -7363,7 +7363,7 @@
   {
     "name_en": "Bread and Butter Pudding",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Dessert", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7587,7 +7587,7 @@
   {
     "name_en": "Mediterranean Bean Salad",
     "name_fr": null,
-    "tags": ["Salad"],
+    "tags": ["Salad", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7737,7 +7737,7 @@
   {
     "name_en": "15 Bean Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Nut-free", "Halal", "Soup", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7871,7 +7871,7 @@
   {
     "name_en": "Lemon Sauce",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Gluten-free", "Egg-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -7949,7 +7949,7 @@
   {
     "name_en": "Cheesy Breakfast or Brunch Egg Burritos",
     "name_fr": null,
-    "tags": ["Breakfast", "Brunch"],
+    "tags": ["Main Meals", "Breakfast", "Vegetarian", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8074,7 +8074,7 @@
   {
     "name_en": "Roasted Herbed Pork Loin",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Halal", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8110,7 +8110,7 @@
   {
     "name_en": "Tijuana Black Bean Soup",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Soup", "Main Meals", "Vegetarian", "Vegan", "Nut-free", "Halal", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8223,7 +8223,7 @@
   {
     "name_en": "Hamburger Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Soup", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8343,7 +8343,7 @@
   {
     "name_en": "Beefaroni (Macaroni, Beef and Tomato Casserole)",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8457,7 +8457,7 @@
   {
     "name_en": "Baked Potatoes",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Vegan", "Nut-free", "Egg-free", "Gluten-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8493,7 +8493,7 @@
   {
     "name_en": "Sweet and Spicy Glazed Chicken Thighs",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8571,7 +8571,7 @@
   {
     "name_en": "Middle Eastern Meatballs -- Kofta Kebabs",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8693,7 +8693,7 @@
   {
     "name_en": "Salsa",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Meal Accompanied", "Vegan", "Vegetarian", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8722,7 +8722,7 @@
   {
     "name_en": "Battered Fish",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8822,7 +8822,7 @@
   {
     "name_en": "Sweet Potato Salad",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Salad", "Vegan", "Vegetarian", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -8935,7 +8935,7 @@
   {
     "name_en": "Breakfast Sandwich",
     "name_fr": null,
-    "tags": ["Breakfast"],
+    "tags": ["Breakfast", "Main Meals", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9006,7 +9006,7 @@
   {
     "name_en": "Apple Fritters",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Dessert", "Vegetarian", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9098,7 +9098,7 @@
   {
     "name_en": "Fish Cakes",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9204,7 +9204,7 @@
   {
     "name_en": "Pea Soup",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Soup", "Halal", "Vegetarian", "Gluten-free", "Egg-free", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9312,7 +9312,7 @@
   {
     "name_en": "Cheese and Garlic Penne",
     "name_fr": null,
-    "tags": ["Main Meals", "Pasta"],
+    "tags": ["Main Meals", "Egg-free", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9411,7 +9411,7 @@
   {
     "name_en": "Coleslaw",
     "name_fr": null,
-    "tags": ["Coleslaw"],
+    "tags": ["Salad", "Vegetarian", "Vegan", "Gluten-free", "Egg-free", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9510,7 +9510,7 @@
   {
     "name_en": "Beef Stew",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Main Meals", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9652,7 +9652,7 @@
   {
     "name_en": "Brown Lentils with Garlic and Onions",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9730,7 +9730,7 @@
   {
     "name_en": "Pasta Primavera Salad",
     "name_fr": null,
-    "tags": ["Main Meals", "Pasta"],
+    "tags": ["Main Meals", "Salad", "Vegetarian", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9837,7 +9837,7 @@
   {
     "name_en": "Polenta",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Gluten-free", "Egg-free", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -9901,7 +9901,7 @@
   {
     "name_en": "Falafels",
     "name_fr": null,
-    "tags": ["Middle Eastern"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10000,7 +10000,7 @@
   {
     "name_en": "Apple Crumble",
     "name_fr": null,
-    "tags": ["Dessert"],
+    "tags": ["Dessert", "Vegetarian", "Egg-free", "Nut-free", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10113,7 +10113,7 @@
   {
     "name_en": "Amish Oatmeal Pie",
     "name_fr": null,
-    "tags": [],
+    "tags": ["Dessert", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10191,7 +10191,7 @@
   {
     "name_en": "Bulgur Wheat Salad",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Salad", "Vegan", "Vegetarian", "Halal", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10283,7 +10283,7 @@
   {
     "name_en": "Stir Fried Vegetables",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegan", "Vegetarian", "Halal", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10340,7 +10340,7 @@
   {
     "name_en": "Rice Pilaf",
     "name_fr": null,
-    "tags": ["Main Meals", "Rice"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Gluten-free", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10433,7 +10433,7 @@
   {
     "name_en": "Cheddar, Apple Muffins",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10518,7 +10518,7 @@
   {
     "name_en": "Corn Fritters",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -10603,7 +10603,7 @@
   {
     "name_en": "Tartare Sauce",
     "name_fr": null,
-    "tags": ["Main Meals"],
+    "tags": ["Main Meals", "Vegetarian", "Halal", "Nut-free", "Egg-free"],
     "description_en": null,
     "description_fr": null,
     "categories": null,

--- a/data/meals-ingredients-substitutes.json
+++ b/data/meals-ingredients-substitutes.json
@@ -3410,7 +3410,7 @@
   {
     "name_en": "Trail Mix Bars",
     "name_fr": null,
-    "tags": ["Dessert", "Vegetarian", "Nut-free", "Halal"],
+    "tags": ["Dessert", "Vegetarian", "Halal"],
     "description_en": null,
     "description_fr": null,
     "categories": null,
@@ -4241,7 +4241,7 @@
   {
     "name_en": "Cucumber Dill Salad",
     "name_fr": null,
-    "tags": ["Meal Accompanied", "Salad", "Egg-free", "Vegan", "Nut-free", "Halal", "Gluten-free", "Vegetarian"],
+    "tags": ["Main Meals", "Salad", "Egg-free", "Vegan", "Nut-free", "Halal", "Gluten-free", "Vegetarian"],
     "description_en": null,
     "description_fr": null,
     "categories": null,

--- a/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
@@ -18,7 +18,8 @@ import { FavoriteMealsFragment } from "../Meals/PersonFavoriteMeals";
 import { graphql } from "babel-plugin-relay/macro";
 import { FavoritesMealPlanQuery } from "./__generated__/FavoritesMealPlanQuery.graphql";
 
-export const Favorites: React.FC = () => {  
+export const Favorites: React.FC = () => {
+  // Fetch favorite meals for current person
   const theme = useTheme();
   const slug = getCurrentPerson().personSlug;
   const combinedQuery = graphql`
@@ -34,6 +35,7 @@ export const Favorites: React.FC = () => {
     }
   `;
 
+  // Load list of favorite meals and meal tags
   const data = useLazyLoadQuery<FavoritesMealPlanQuery>(
     combinedQuery,
     { slug: slug },
@@ -49,7 +51,8 @@ export const Favorites: React.FC = () => {
 
   let [searchText, setSearchText] = useState("");
   let [selectedTag, setSelectedTag] = useState("");
-  
+
+  // Modify favorites list based on meal search text and meal tag
   let search = (searchText: string, tag: string) => {
     const mapped = favMeals
       .map((f: any) => f.meal)

--- a/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
@@ -5,7 +5,9 @@ import {
   FormControl,
   InputAdornment,
   InputLabel,
+  MenuItem,
   OutlinedInput,
+  Select,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -39,9 +41,16 @@ export const Favorites: React.FC = () => {
   );
   const [meals] = useRefetchableFragment(FavoriteMealsFragment, data as any);
   const favMeals = meals.people?.nodes[0].favoriteMeals.nodes || [];
+  const favMealTags: string[] = Array.from(
+    new Set(
+      (favMeals || []).flatMap((f: any) => f?.meal?.tags || [])
+    )
+  );
 
   let [searchText, setSearchText] = useState("");
-  let search = (searchText: string) => {
+  let [selectedTag, setSelectedTag] = useState("");
+  
+  let search = (searchText: string, tag: string) => {
     const mapped = favMeals
       .map((f: any) => f.meal)
       .filter((m: any) => m != null);
@@ -53,13 +62,20 @@ export const Favorites: React.FC = () => {
       if (aName > bName) return 1;
       return 0;
     });
-
-    if (searchText === "") {
-      return sortedMeals;
+    
+    if (searchText !== "") {
+      sortedMeals = sortedMeals.filter((m: any) =>
+        (m.nameEn || "").match(new RegExp(searchText, "i"))
+      );
     }
-    return sortedMeals.filter((m: any) =>
-      (m.nameEn || "").match(new RegExp(searchText, "i"))
-    );
+    
+    if (tag !== "") {
+      sortedMeals = sortedMeals.filter((m: any) =>
+        (m.tags || []).includes(tag)
+      );
+    }
+    
+    return sortedMeals;
   };
 
   return (
@@ -87,30 +103,58 @@ export const Favorites: React.FC = () => {
               Favorites
             </Typography>
 
-            <FormControl
-              variant="filled"
-              sx={{ width: "99%", color: `${theme.palette.primary.contrastText}` }}
-            >
-              <InputLabel sx={{ color: `${theme.palette.primary.contrastText}` }}>
-                Search for meals
-              </InputLabel>
-              <OutlinedInput
-                sx={{
-                  backgroundColor: theme.palette.primary.main,
-                  color: `${theme.palette.primary.contrastText}`,
-                }}
-                notched={false}
-                startAdornment={
-                  <InputAdornment position="start">
-                    <SearchIcon htmlColor={theme.palette.primary.contrastText} />
-                  </InputAdornment>
-                }
-                value={searchText}
-                onChange={(e) => {
-                  setSearchText(e.target.value);
-                }}
-              />
-            </FormControl>
+            <Box display="flex" gap={2} width="99%">
+              <FormControl
+                variant="filled"
+                sx={{ flex: 2, color: `${theme.palette.primary.contrastText}` }}
+              >
+                <InputLabel sx={{ color: `${theme.palette.primary.contrastText}` }}>
+                  Search for meals
+                </InputLabel>
+                <OutlinedInput
+                  sx={{
+                    backgroundColor: theme.palette.primary.main,
+                    color: `${theme.palette.primary.contrastText}`,
+                  }}
+                  notched={false}
+                  startAdornment={
+                    <InputAdornment position="start">
+                      <SearchIcon htmlColor={theme.palette.primary.contrastText} />
+                    </InputAdornment>
+                  }
+                  value={searchText}
+                  onChange={(e) => {
+                    setSearchText(e.target.value);
+                  }}
+                />
+              </FormControl>
+              
+              <FormControl
+                variant="filled"
+                sx={{ flex: 1, color: `${theme.palette.primary.contrastText}` }}
+              >
+                <InputLabel sx={{ color: `${theme.palette.primary.contrastText}` }}>
+                  Filter by tag
+                </InputLabel>
+                <Select
+                  value={selectedTag}
+                  onChange={(e) => setSelectedTag(e.target.value)}
+                  sx={{
+                    backgroundColor: theme.palette.primary.main,
+                    color: `${theme.palette.primary.contrastText}`,
+                  }}
+                >
+                  <MenuItem value="">
+                    <em>All tags</em>
+                  </MenuItem>
+                  {favMealTags.map((tag) => (
+                    <MenuItem key={tag} value={tag}>
+                      {tag}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
 
             {data.gqLocalState?.selectedMeal?.nameEn ? (
               <Typography sx={{ color: `${theme.palette.primary.contrastText}` }}>
@@ -132,31 +176,8 @@ export const Favorites: React.FC = () => {
             ) : null}
 
             <Box mt={1} width="100%">
-              {/* {sortedFavMeals.map((fav: any) => {
-                const meal = fav.meal;
-                return (
-                  <Button
-                    sx={{ 
-                      textTransform: "capitalize", 
-                      width: "49%",
-                      flexDirection: "column",
-                      alignItems: "flex-start",
-                      margin: "0.2em"
-                    }}
-                    variant="contained"
-                    color="primary"
-                    key={meal.id}
-                    onClick={() => {
-                      setSelectedMeal(meal);
-                    }}
-                  >
-                    <Typography fontWeight="500">{meal?.nameEn ?? 'Unnamed'}</Typography>
-                    <Typography fontSize="0.8em">{meal?.tags?.join(', ')}</Typography>
-                  </Button>
-                );
-              })} */}
               {
-                search(searchText).map((m: any) => {
+                search(searchText, selectedTag).map((m: any) => {
                   return (
                     <Button
                     sx={{ 

--- a/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
@@ -1,10 +1,15 @@
+import SearchIcon from "@mui/icons-material/Search";
 import {
   Box,
   Button,
+  FormControl,
+  InputAdornment,
+  InputLabel,
+  OutlinedInput,
   Typography,
   useTheme,
 } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 import { useRefetchableFragment, useLazyLoadQuery } from "react-relay";
 import { getCurrentPerson, clearSelectedMeal, setSelectedMeal } from "../../state/state";
 import { FavoriteMealsFragment } from "../Meals/PersonFavoriteMeals";
@@ -33,14 +38,29 @@ export const Favorites: React.FC = () => {
     { fetchPolicy: "store-or-network" }
   );
   const [meals] = useRefetchableFragment(FavoriteMealsFragment, data as any);
-  const favMeals = meals.people?.nodes[0].favoriteMeals.nodes;
-  const sortedFavMeals = (favMeals || []).slice().sort((a: any, b: any) => {
-    const aName = (a?.meal?.nameEn || "").toLowerCase();
-    const bName = (b?.meal?.nameEn || "").toLowerCase();
-    if (aName < bName) return -1;
-    if (aName > bName) return 1;
-    return 0;
-  });
+  const favMeals = meals.people?.nodes[0].favoriteMeals.nodes || [];
+
+  let [searchText, setSearchText] = useState("");
+  let search = (searchText: string) => {
+    const mapped = favMeals
+      .map((f: any) => f.meal)
+      .filter((m: any) => m != null);
+
+    let sortedMeals = mapped.slice().sort((a: any, b: any) => {
+      const aName = (a?.nameEn || "").toLowerCase();
+      const bName = (b?.nameEn || "").toLowerCase();
+      if (aName < bName) return -1;
+      if (aName > bName) return 1;
+      return 0;
+    });
+
+    if (searchText === "") {
+      return sortedMeals;
+    }
+    return sortedMeals.filter((m: any) =>
+      (m.nameEn || "").match(new RegExp(searchText, "i"))
+    );
+  };
 
   return (
     <React.Fragment>
@@ -67,6 +87,31 @@ export const Favorites: React.FC = () => {
               Favorites
             </Typography>
 
+            <FormControl
+              variant="filled"
+              sx={{ width: "99%", color: `${theme.palette.primary.contrastText}` }}
+            >
+              <InputLabel sx={{ color: `${theme.palette.primary.contrastText}` }}>
+                Search for meals
+              </InputLabel>
+              <OutlinedInput
+                sx={{
+                  backgroundColor: theme.palette.primary.main,
+                  color: `${theme.palette.primary.contrastText}`,
+                }}
+                notched={false}
+                startAdornment={
+                  <InputAdornment position="start">
+                    <SearchIcon htmlColor={theme.palette.primary.contrastText} />
+                  </InputAdornment>
+                }
+                value={searchText}
+                onChange={(e) => {
+                  setSearchText(e.target.value);
+                }}
+              />
+            </FormControl>
+
             {data.gqLocalState?.selectedMeal?.nameEn ? (
               <Typography sx={{ color: `${theme.palette.primary.contrastText}` }}>
                 {data.gqLocalState.selectedMeal.nameEn}
@@ -87,7 +132,7 @@ export const Favorites: React.FC = () => {
             ) : null}
 
             <Box mt={1} width="100%">
-              {sortedFavMeals.map((fav: any) => {
+              {/* {sortedFavMeals.map((fav: any) => {
                 const meal = fav.meal;
                 return (
                   <Button
@@ -107,6 +152,29 @@ export const Favorites: React.FC = () => {
                   >
                     <Typography fontWeight="500">{meal?.nameEn ?? 'Unnamed'}</Typography>
                     <Typography fontSize="0.8em">{meal?.tags?.join(', ')}</Typography>
+                  </Button>
+                );
+              })} */}
+              {
+                search(searchText).map((m: any) => {
+                  return (
+                    <Button
+                    sx={{ 
+                      textTransform: "capitalize", 
+                      width: "49%",
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                      margin: "0.2em"
+                    }}
+                    variant="contained"
+                    color="primary"
+                    key={m.id ?? m.rowId}
+                    onClick={() => {
+                      setSelectedMeal(m);
+                    }}
+                  >
+                    <Typography fontWeight={"500"}>{m.nameEn ?? "Unnamed"} </Typography>
+                    <Typography fontSize={"0.8em"}>{m.tags?.join(", ")}</Typography>
                   </Button>
                 );
               })}

--- a/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/Favorites.tsx
@@ -1,0 +1,118 @@
+import {
+  Box,
+  Button,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import React from "react";
+import { useRefetchableFragment, useLazyLoadQuery } from "react-relay";
+import { getCurrentPerson, clearSelectedMeal, setSelectedMeal } from "../../state/state";
+import { FavoriteMealsFragment } from "../Meals/PersonFavoriteMeals";
+import { graphql } from "babel-plugin-relay/macro";
+import { FavoritesMealPlanQuery } from "./__generated__/FavoritesMealPlanQuery.graphql";
+
+export const Favorites: React.FC = () => {  
+  const theme = useTheme();
+  const slug = getCurrentPerson().personSlug;
+  const combinedQuery = graphql`
+    query FavoritesMealPlanQuery($slug: String!) {
+      gqLocalState {
+        selectedMeal {
+          nameEn
+          rowId
+          id
+        }
+      }
+      ...PersonFavoriteMeals_favorites @arguments(slug: $slug)
+    }
+  `;
+
+  const data = useLazyLoadQuery<FavoritesMealPlanQuery>(
+    combinedQuery,
+    { slug: slug },
+    { fetchPolicy: "store-or-network" }
+  );
+  const [meals] = useRefetchableFragment(FavoriteMealsFragment, data as any);
+  const favMeals = meals.people?.nodes[0].favoriteMeals.nodes;
+  const sortedFavMeals = (favMeals || []).slice().sort((a: any, b: any) => {
+    const aName = (a?.meal?.nameEn || "").toLowerCase();
+    const bName = (b?.meal?.nameEn || "").toLowerCase();
+    if (aName < bName) return -1;
+    if (aName > bName) return 1;
+    return 0;
+  });
+
+  return (
+    <React.Fragment>
+      <div
+        style={{
+          marginTop: "10px"
+        }}
+      >
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems={"flex-start"}
+            bgcolor="primary.dark"
+            displayPrint={"none"}
+            mt={"10px"}
+            borderRadius={"10px"}
+            padding={"0.5rem"}
+          >
+            <Typography
+              overflow="hidden"
+              color="primary.contrastText"
+              variant={"h5"}
+            >
+              Favorites
+            </Typography>
+
+            {data.gqLocalState?.selectedMeal?.nameEn ? (
+              <Typography sx={{ color: `${theme.palette.primary.contrastText}` }}>
+                {data.gqLocalState.selectedMeal.nameEn}
+
+                <Button
+                  variant="contained"
+                  size="small"
+                  color="primary"
+                  sx={{ margin: "0 1em", padding: "0 0", minWidth: "2em" }}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    clearSelectedMeal();
+                  }}
+                >
+                  x
+                </Button>
+              </Typography>
+            ) : null}
+
+            <Box mt={1} width="100%">
+              {sortedFavMeals.map((fav: any) => {
+                const meal = fav.meal;
+                return (
+                  <Button
+                    sx={{ 
+                      textTransform: "capitalize", 
+                      width: "49%",
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                      margin: "0.2em"
+                    }}
+                    variant="contained"
+                    color="primary"
+                    key={meal.id}
+                    onClick={() => {
+                      setSelectedMeal(meal);
+                    }}
+                  >
+                    <Typography fontWeight="500">{meal?.nameEn ?? 'Unnamed'}</Typography>
+                    <Typography fontSize="0.8em">{meal?.tags?.join(', ')}</Typography>
+                  </Button>
+                );
+              })}
+            </Box>
+          </Box>
+      </div>
+    </React.Fragment>
+ );
+};

--- a/mealplanner-ui/src/pages/MealPlans/MealPlan.tsx
+++ b/mealplanner-ui/src/pages/MealPlans/MealPlan.tsx
@@ -6,6 +6,7 @@ import { useParams } from "react-router-dom";
 import { Calendar } from "./Calendar";
 import { MealPlanHeader } from "./MealPlanHeader";
 import { SearchMeal } from "./SearchMeal";
+import { Favorites } from "./Favorites";
 import { MealPlanQuery } from "./__generated__/MealPlanQuery.graphql";
 
 /* Meal plan query */
@@ -60,6 +61,7 @@ export const MealPlan = () => {
           <section>
             <Calendar mealPlan={data.mealPlan!} />
           </section>
+          <Favorites />
         </Grid>
       </Grid>
     </React.Fragment>

--- a/mealplanner-ui/src/pages/MealPlans/__generated__/FavoritesMealPlanQuery.graphql.ts
+++ b/mealplanner-ui/src/pages/MealPlans/__generated__/FavoritesMealPlanQuery.graphql.ts
@@ -1,0 +1,274 @@
+/**
+ * @generated SignedSource<<1ce334861d2916529459e623749a8005>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FavoritesMealPlanQuery$variables = {
+  slug: string;
+};
+export type FavoritesMealPlanQuery$data = {
+  readonly gqLocalState: {
+    readonly selectedMeal: {
+      readonly nameEn: string;
+      readonly rowId: any;
+      readonly id: string;
+    } | null;
+  };
+  readonly " $fragmentSpreads": FragmentRefs<"PersonFavoriteMeals_favorites">;
+};
+export type FavoritesMealPlanQuery = {
+  variables: FavoritesMealPlanQuery$variables;
+  response: FavoritesMealPlanQuery$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "slug"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "nameEn",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "rowId",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "kind": "ClientExtension",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GQLocalState",
+      "kind": "LinkedField",
+      "name": "gqLocalState",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SelectedMeal",
+          "kind": "LinkedField",
+          "name": "selectedMeal",
+          "plural": false,
+          "selections": [
+            (v1/*: any*/),
+            (v2/*: any*/),
+            (v3/*: any*/)
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FavoritesMealPlanQuery",
+    "selections": [
+      {
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "slug",
+            "variableName": "slug"
+          }
+        ],
+        "kind": "FragmentSpread",
+        "name": "PersonFavoriteMeals_favorites"
+      },
+      (v4/*: any*/)
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "FavoritesMealPlanQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "fields": [
+              {
+                "fields": [
+                  {
+                    "kind": "Variable",
+                    "name": "equalTo",
+                    "variableName": "slug"
+                  }
+                ],
+                "kind": "ObjectValue",
+                "name": "slug"
+              }
+            ],
+            "kind": "ObjectValue",
+            "name": "filter"
+          },
+          {
+            "kind": "Literal",
+            "name": "first",
+            "value": 1
+          }
+        ],
+        "concreteType": "PeopleConnection",
+        "kind": "LinkedField",
+        "name": "people",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Person",
+            "kind": "LinkedField",
+            "name": "nodes",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FavoriteMealsConnection",
+                "kind": "LinkedField",
+                "name": "favoriteMeals",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FavoriteMeal",
+                    "kind": "LinkedField",
+                    "name": "nodes",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Meal",
+                        "kind": "LinkedField",
+                        "name": "meal",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v1/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "nameFr",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "descriptionEn",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "descriptionFr",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "categories",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "tags",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "code",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "photoUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "videoUrl",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      (v4/*: any*/)
+    ]
+  },
+  "params": {
+    "cacheID": "0a5ae228b61b0ceb2f36799537d7d73c",
+    "id": null,
+    "metadata": {},
+    "name": "FavoritesMealPlanQuery",
+    "operationKind": "query",
+    "text": "query FavoritesMealPlanQuery(\n  $slug: String!\n) {\n  ...PersonFavoriteMeals_favorites_20J5Pl\n}\n\nfragment PersonFavoriteMeals_favorites_20J5Pl on Query {\n  people(filter: {slug: {equalTo: $slug}}, first: 1) {\n    nodes {\n      favoriteMeals {\n        nodes {\n          meal {\n            rowId\n            nameEn\n            nameFr\n            descriptionEn\n            descriptionFr\n            categories\n            tags\n            code\n            photoUrl\n            videoUrl\n            id\n          }\n          id\n        }\n      }\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "694be900db8a05d29cdbb0c8f994727f";
+
+export default node;


### PR DESCRIPTION
**Describe the technical changes contained in this PR**
1. In the individual meal plan page, there is now a 'favorites' section that shows the user's favorite meals to select from
2. The favorites section (mealplanner\mealplanner-ui\src\pages\MealPlans\Favorites.tsx) contains the user's favorite meals, as well as a search bar to search the favorite meals by name and a dropdown to filter by meal tag
3. Meal tags deemed unnecessary have been omitted from and essential meal tags have been introduced to recipes_seed.sql, seed.sql, meal_seed.sql and meals-ingredients-substitutes.json

**Previous behaviour**
1. There was no favorite meals section for the user in the individual meal plan page
2. A lot of meals had unnecessary/repetitive tags

**New behaviour**
1. A favorites section in the individual meal plan page, where users can select meals from their favorite meals for meal planning, and can also filter them by meal tag (dropdown) and by name (search field)
2. Some unnecessary tags are now absent in the tags filter of meals page, and are replaced with useful tags

**Related issues addressed by this PR**
Includes fixes for bugs in issue #738 as well

**Have the following been addressed?**
- [ ] Have test cases been created for all of the changes?
- [ ] Do all of the test cases pass?
- [ ] Has the testing been done using the default docker-compose environment?
- [ ] Are documentation changes required?
- [ ] Does this change break or alter existing behaviour?